### PR TITLE
feat: add Google Analytics tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { RootProvider } from "fumadocs-ui/provider";
+import Script from "next/script";
 import "./globals.css";
 
 const geistSans = localFont({
@@ -30,6 +31,19 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <RootProvider>{children}</RootProvider>
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-ED4GVN8YVW"
+          strategy="afterInteractive"
+        />
+        <Script id="gtag-init" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'G-ED4GVN8YVW');
+          `}
+        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- integrate Google Analytics in the root layout using gtag.js

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5acb6948083239c5d977b6d63b590