### PR TITLE
chore: add next-intl configuration

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,9 @@
+export const locales = ["en", "zh"] as const;
+export const defaultLocale = "en";
+
+export const i18n = {
+  locales,
+  defaultLocale,
+} as const;
+
+export type Locale = (typeof locales)[number];

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,9 @@
 // next.config.mjs
 import { createMDX } from "fumadocs-mdx/next";
+import createNextIntlPlugin from "next-intl/plugin";
 
 const withMDX = createMDX();
+const withNextIntl = createNextIntlPlugin("./i18n.ts");
 
 /** @type {import('next').NextConfig} */
 const config = {
@@ -10,4 +12,4 @@ const config = {
   images: { unoptimized: true }, // 避免使用 Next Image 优化服务
 };
 
-export default withMDX(config);
+export default withNextIntl(withMDX(config));

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@orama/orama": "^3.1.13",
     "@orama/tokenizers": "^3.1.13",
+    "@radix-ui/react-slot": "^1.2.3",
     "@types/mdx": "^2.0.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -22,13 +23,13 @@
     "fumadocs-ui": "^15.7.11",
     "lucide-react": "^0.544.0",
     "next": "^15.5.3",
+    "next-intl": "^4.3.8",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.3.1",
-    "@radix-ui/react-slot": "^1.2.3"
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       next:
         specifier: ^15.5.3
         version: 15.5.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next-intl:
+        specifier: ^4.3.8
+        version: 4.3.8(next@15.5.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -452,6 +455,36 @@ packages:
     resolution:
       {
         integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==,
+      }
+
+  "@formatjs/ecma402-abstract@2.3.4":
+    resolution:
+      {
+        integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==,
+      }
+
+  "@formatjs/fast-memoize@2.2.7":
+    resolution:
+      {
+        integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==,
+      }
+
+  "@formatjs/icu-messageformat-parser@2.11.2":
+    resolution:
+      {
+        integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==,
+      }
+
+  "@formatjs/icu-skeleton-parser@1.8.14":
+    resolution:
+      {
+        integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==,
+      }
+
+  "@formatjs/intl-localematcher@0.5.10":
+    resolution:
+      {
+        integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==,
       }
 
   "@formatjs/intl-localematcher@0.6.1":
@@ -1327,6 +1360,12 @@ packages:
     resolution:
       {
         integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==,
+      }
+
+  "@schummar/icu-type-parser@1.21.5":
+    resolution:
+      {
+        integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==,
       }
 
   "@shikijs/core@3.12.2":
@@ -2342,6 +2381,12 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution:
+      {
+        integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==,
+      }
+
   decode-named-character-reference@1.2.0:
     resolution:
       {
@@ -3205,6 +3250,12 @@ packages:
         integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==,
       }
     engines: { node: ">= 0.4" }
+
+  intl-messageformat@10.7.16:
+    resolution:
+      {
+        integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==,
+      }
 
   is-alphabetical@2.0.1:
     resolution:
@@ -4137,6 +4188,19 @@ packages:
         integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
       }
     engines: { node: ">= 0.6" }
+
+  next-intl@4.3.8:
+    resolution:
+      {
+        integrity: sha512-epUuRSL1KRQtDdFVRb5j7ZaaF7Sx/aivVA7VY0fc5g1pmpT90ylK6AaBdNsOnc5n+AERVn+zO5HoBsXO0lhTZA==,
+      }
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   next-themes@0.4.6:
     resolution:
@@ -5196,6 +5260,14 @@ packages:
       "@types/react":
         optional: true
 
+  use-intl@4.3.8:
+    resolution:
+      {
+        integrity: sha512-L4mcWCriZCw+qySIk5Octy9ioRNTuFu4y2kTw3NIKfKRk0xAvfobX7/5VHk+eCDJFJeBEqJov/qRe83LDfbqyg==,
+      }
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+
   use-sidecar@1.1.3:
     resolution:
       {
@@ -5468,6 +5540,32 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
 
   "@floating-ui/utils@0.2.10": {}
+
+  "@formatjs/ecma402-abstract@2.3.4":
+    dependencies:
+      "@formatjs/fast-memoize": 2.2.7
+      "@formatjs/intl-localematcher": 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  "@formatjs/fast-memoize@2.2.7":
+    dependencies:
+      tslib: 2.8.1
+
+  "@formatjs/icu-messageformat-parser@2.11.2":
+    dependencies:
+      "@formatjs/ecma402-abstract": 2.3.4
+      "@formatjs/icu-skeleton-parser": 1.8.14
+      tslib: 2.8.1
+
+  "@formatjs/icu-skeleton-parser@1.8.14":
+    dependencies:
+      "@formatjs/ecma402-abstract": 2.3.4
+      tslib: 2.8.1
+
+  "@formatjs/intl-localematcher@0.5.10":
+    dependencies:
+      tslib: 2.8.1
 
   "@formatjs/intl-localematcher@0.6.1":
     dependencies:
@@ -6035,6 +6133,8 @@ snapshots:
   "@rtsao/scc@1.1.0": {}
 
   "@rushstack/eslint-patch@1.12.0": {}
+
+  "@schummar/icu-type-parser@1.21.5": {}
 
   "@shikijs/core@3.12.2":
     dependencies:
@@ -6638,6 +6738,8 @@ snapshots:
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -7407,6 +7509,13 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  intl-messageformat@10.7.16:
+    dependencies:
+      "@formatjs/ecma402-abstract": 2.3.4
+      "@formatjs/fast-memoize": 2.2.7
+      "@formatjs/icu-messageformat-parser": 2.11.2
+      tslib: 2.8.1
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -8165,6 +8274,16 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  next-intl@4.3.8(next@15.5.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(typescript@5.9.2):
+    dependencies:
+      "@formatjs/intl-localematcher": 0.5.10
+      negotiator: 1.0.0
+      next: 15.5.3(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      use-intl: 4.3.8(react@19.1.1)
+    optionalDependencies:
+      typescript: 5.9.2
 
   next-themes@0.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -8965,6 +9084,13 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       "@types/react": 19.1.12
+
+  use-intl@4.3.8(react@19.1.1):
+    dependencies:
+      "@formatjs/fast-memoize": 2.2.7
+      "@schummar/icu-type-parser": 1.21.5
+      intl-messageformat: 10.7.16
+      react: 19.1.1
 
   use-sidecar@1.1.3(@types/react@19.1.12)(react@19.1.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add `i18n.ts` with supported locales
- configure Next.js to use `next-intl`
- install `next-intl` dependency

## Testing
- `pnpm build` *(fails: stuck while exporting pages)*

------
https://chatgpt.com/codex/tasks/task_e_68c7012be00083238ad1872e3655e9cc