### PR TITLE
style: distinguish docs title from content headings

### DIFF
--- a/app/docs/[...slug]/page.tsx
+++ b/app/docs/[...slug]/page.tsx
@@ -23,7 +23,9 @@ export default async function DocPage({ params }: Param) {
   return (
     <DocsPage toc={page.data.toc}>
       <DocsBody>
-        <h1>{page.data.title}</h1>
+        <h1 className="mb-4 text-3xl font-extrabold tracking-tight md:text-4xl">
+          {page.data.title}
+        </h1>
         <Mdx components={getMDXComponents()} />
       </DocsBody>
     </DocsPage>


### PR DESCRIPTION
## Summary
- style docs page titles with custom typography to avoid visual duplication with in-page `#` headings

## Testing
- `pnpm build` *(fails: Command failed with exit code 1 while collecting page data)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f588e88c832d9b742ab846ab1b6f