### PR TITLE
Fix frontmatter tags template

### DIFF
--- a/app/components/Contribute.tsx
+++ b/app/components/Contribute.tsx
@@ -31,7 +31,7 @@ function buildGithubNewUrl(dirPath: string, filename: string, title: string) {
   const file = filename.endsWith(".mdx") ? filename : `${filename}.mdx`;
   const fullDir = `${DOCS_BASE}/${dirPath}`.replace(/\/+/g, "/");
   const frontMatter = `---
-title: "${title || "New Article"}"
+title: '${title || "New Article"}'
 description: ""
 date: "${new Date().toISOString().slice(0, 10)}"
 tags:

--- a/app/components/Contribute.tsx
+++ b/app/components/Contribute.tsx
@@ -31,10 +31,11 @@ function buildGithubNewUrl(dirPath: string, filename: string, title: string) {
   const file = filename.endsWith(".mdx") ? filename : `${filename}.mdx`;
   const fullDir = `${DOCS_BASE}/${dirPath}`.replace(/\/+/g, "/");
   const frontMatter = `---
-title: ${title || "New Article"}
-description:
-date: ${new Date().toISOString().slice(0, 10)}
-tags: []
+title: "${title || "New Article"}"
+description: ""
+date: "${new Date().toISOString().slice(0, 10)}"
+tags:
+  - tag-one
 ---
 
 # ${title || "New Article"}


### PR DESCRIPTION
## Summary
- update the contributor dialog template to generate YAML frontmatter with a list-based tags field
- wrap default frontmatter values in quotes and add placeholder values for description and tags

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cbef907664832da4048d14e64e9216