### PR TITLE
feat(docs): 新增脚本以自动生成 CommunityShare 索引页

### DIFF
--- a/app/docs/CommunityShare/index.mdx
+++ b/app/docs/CommunityShare/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "群友分享"
-date: "2025-09-18"
+date: "2025-09-21"
 ---
 
 欢迎来到群友分享板块！无论你是技术极客，还是热爱生活，都欢迎积极投稿！
@@ -11,25 +11,19 @@ date: "2025-09-18"
 
 ## 技术分享
 
-- [常用Markdown语法](/docs/CommunityShare/Geek/CommonUsedMarkdown)
-
-- [Git入门操作指南-程序员必会的git小技巧](/docs/CommunityShare/Geek/git101)
-
-- [用闲置树莓派搭建一个Minecraft服务器](/docs/CommunityShare/Geek/raspberry-guide)
-
-- [常用Katex语法](/docs/CommunityShare/Geek/Katex/index)
+- [技术分享](/docs/CommunityShare/Geek)
+  - [常用Markdown语法](/docs/CommunityShare/Geek/CommonUsedMarkdown)
+  - [Git入门操作指南-程序员必会的git小技巧](/docs/CommunityShare/Geek/git101)
+  - [用闲置树莓派搭建一个Minecraft服务器](/docs/CommunityShare/Geek/raspberry-guide)
+  - [常用Katex语法](/docs/CommunityShare/Geek/Katex)
+    - [个人常用字符](/docs/CommunityShare/Geek/Katex/Seb1)
+    - [数学公式语法](/docs/CommunityShare/Geek/Katex/Seb2)
 
 ## 心理健康
 
-- [程序员 Burnout 自救指南](/docs/CommunityShare/MentalHealth/burnout-guide) - 识别和应对职业倦怠
+- [心理健康](/docs/CommunityShare/MentalHealth)
+  - [程序员 Burnout 自救指南](/docs/CommunityShare/MentalHealth/burnout-guide)
 
 ## RAG
 
-- [RAG toy demo](/docs/CommunityShare/RAG/rag)
-
-## 身体健康
-
-- 久坐办公的解决方案
-- 程序员健身指南
-- 饮食与营养建议
-- 睡眠质量改善
+  - [RAG](/docs/CommunityShare/RAG/rag)

--- a/scripts/generate-community-index.js
+++ b/scripts/generate-community-index.js
@@ -1,0 +1,107 @@
+// scripts/generate-community-index.js (FINAL VERSION with Multi-Level Nesting)
+
+const fs = require('fs');
+const path = require('path');
+const { glob } = require('glob');
+const matter = require('gray-matter');
+
+// --- 配置区 ---
+const communityShareDir = path.join(__dirname, '../app/docs/CommunityShare');
+const outputFile = path.join(communityShareDir, 'index.mdx');
+
+const categoryDisplayNames = {
+  Geek: '技术分享',
+  MentalHealth: '心理健康',
+  RAG: 'RAG',
+};
+
+const headerContent = `---
+title: "群友分享"
+date: "${new Date().toISOString().split('T')[0]}"
+---
+
+欢迎来到群友分享板块！无论你是技术极客，还是热爱生活，都欢迎积极投稿！
+
+一篇微不足道的文章或许可以帮助一个迷茫的陌生人~
+
+> 转载文章请先联系原作者获取授权，谢谢！
+`;
+
+// --- 主逻辑 ---
+async function generateIndex() {
+  try {
+    const categories = fs.readdirSync(communityShareDir, { withFileTypes: true })
+      .filter(dirent => dirent.isDirectory())
+      .map(dirent => dirent.name);
+
+    let allLinksContent = '';
+
+    for (const category of categories) {
+      const categoryPath = path.join(communityShareDir, category);
+      const files = await glob(`${categoryPath.replace(/\\/g, '/')}/**/*.{md,mdx}`);
+
+      if (files.length === 0) continue;
+
+      // 自定义排序逻辑
+      files.sort((a, b) => {
+        const dirA = path.dirname(a);
+        const dirB = path.dirname(b);
+        if (dirA !== dirB) {
+          return dirA.localeCompare(dirB);
+        }
+        const isAIndex = path.basename(a).startsWith('index.');
+        const isBIndex = path.basename(b).startsWith('index.');
+        if (isAIndex) return -1;
+        if (isBIndex) return 1;
+        return path.basename(a).localeCompare(path.basename(b));
+      });
+
+      const categoryTitle = categoryDisplayNames[category] || category;
+      allLinksContent += `## ${categoryTitle}\n\n`;
+
+      // --- 支持多级嵌套的链接生成逻辑 ---
+      const links = files.map(file => {
+        const fileContent = fs.readFileSync(file, 'utf8');
+        const { data: frontmatter } = matter(fileContent);
+
+        const title = frontmatter.title || path.basename(file, path.extname(file));
+        
+        const relativePath = path.relative(communityShareDir, file);
+        const urlPath = relativePath.replace(/\\/g, '/').replace(/\.(mdx|md)$/, '');
+        const finalUrl = urlPath.endsWith('/index') ? urlPath.slice(0, -6) : urlPath;
+        const url = `/docs/CommunityShare/${finalUrl}`;
+        
+        // --- 动态计算缩进深度 ---
+        const relativeToCategory = path.relative(categoryPath, file);
+        const dirOfFile = path.dirname(relativeToCategory);
+
+        // 1. 计算文件所在目录的深度
+        // 如果文件在根目录(.), 深度为0, 否则按路径分隔符数量计算
+        const depth = dirOfFile === '.' ? 0 : dirOfFile.split(path.sep).length;
+        
+        // 2. 判断是否为 index 文件
+        const isIndex = path.basename(file).startsWith('index.');
+        
+        // 3. index 文件使用目录深度, 非 index 文件在目录深度的基础上再缩进一级
+        const indentLevel = isIndex ? depth : depth + 1;
+        
+        const prefix = '  '.repeat(indentLevel) + '- ';
+
+        return `${prefix}[${title}](${url})`;
+      });
+      // --- 新链接生成逻辑结束 ---
+      
+      allLinksContent += links.join('\n') + '\n\n';
+    }
+
+    const finalContent = `${headerContent}\n${allLinksContent.trim()}`;
+    fs.writeFileSync(outputFile, finalContent);
+
+    console.log(`Successfully generated index for CommunityShare at ${outputFile}`);
+  } catch (error) {
+    console.error('Error generating CommunityShare index file:', error);
+    process.exit(1);
+  }
+}
+
+generateIndex();


### PR DESCRIPTION
Purpose:
为了解决 CommunityShare 索引页 (index.mdx) 需要手动维护的问题，本次提交引入了一个自动化的 Node.js 脚本。该脚本能够根据实际文件目录结构，动态生成一个结构清晰、链接准确、始终保持最新的索引页。

Key Changes:
新增索引生成脚本:
        在 scripts/ 目录下添加了 generate-community-index.js 文件。
更新索引页:
        使用新脚本生成了最新的 app/docs/CommunityShare/index.mdx 文件，以展示脚本的运行效果。
脚本核心功能 (Script Features)
    自动扫描: 脚本会自动扫描 CommunityShare 下的所有分类目录（如 Geek, computer-science 等）。
    支持多级嵌套: 能够正确处理任意深度的目录结构（例如 .../data-structures/array/），并生成对应的层级缩进。
    智能排序: 在每个目录层级中，index.mdx (作为该层级的概述页) 会被优先排列，其余文件则按字母顺序排序。
    读取元数据: 脚本会自动读取每个 .mdx 文件头部的 Frontmatter，使用其中定义的 title作为链接的显示文本。

How to Use:
在项目根目录下运行以下命令即可更新索引：
node scripts/generate-community-index.js

Next Steps:
依赖库glob和gray-matter由于我配置原因未写入package.json，在此之后才能做GitHub Actions。
没玩明白GitHub Actions workflows工作流，需要集成才能实现自动化。