### PR TITLE
feat: 对AI助手增加了书生大模型的支持，并解耦了AI模块的代码便于后续复用

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,13 +2,13 @@ import { streamText, UIMessage, convertToModelMessages } from "ai";
 import { getModel, requiresApiKey, type AIProvider } from "@/lib/ai/models";
 import { buildSystemMessage } from "@/lib/ai/prompt";
 
-// Allow streaming responses up to 30 seconds
+// 流式响应最长30秒
 export const maxDuration = 30;
 
 interface ChatRequest {
   messages: UIMessage[];
-  system?: string; // System message forwarded from AssistantChatTransport
-  tools?: unknown; // Frontend tools forwarded from AssistantChatTransport
+  system?: string;
+  tools?: unknown;
   pageContext?: {
     title?: string;
     description?: string;
@@ -25,11 +25,11 @@ export async function POST(req: Request) {
       messages,
       system,
       pageContext,
-      provider = "openai", // Default to OpenAI
+      provider = "intern", // 默认使用书生模型
       apiKey,
     }: ChatRequest = await req.json();
 
-    // Validate API key for providers that require it
+    // 对指定Provider验证key是否存在
     if (requiresApiKey(provider) && (!apiKey || apiKey.trim() === "")) {
       return Response.json(
         {
@@ -40,13 +40,13 @@ export async function POST(req: Request) {
       );
     }
 
-    // Build system message with page context
+    // 构建系统消息，包含页面上下文
     const systemMessage = buildSystemMessage(system, pageContext);
 
-    // Get AI model instance based on provider
+    // 根据Provider获取 AI 模型实例
     const model = getModel(provider, apiKey);
 
-    // Generate streaming response
+    // 生成流式响应
     const result = streamText({
       model: model,
       system: systemMessage,
@@ -57,7 +57,7 @@ export async function POST(req: Request) {
   } catch (error) {
     console.error("Chat API error:", error);
 
-    // Handle specific model creation errors
+    // 处理特定模型创建错误
     if (error instanceof Error && error.message.includes("API key")) {
       return Response.json({ error: error.message }, { status: 400 });
     }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,89 +1,52 @@
-import { createOpenAI } from "@ai-sdk/openai";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { streamText, UIMessage, convertToModelMessages } from "ai";
+import { getModel, requiresApiKey, type AIProvider } from "@/lib/ai/models";
+import { buildSystemMessage } from "@/lib/ai/prompt";
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
 
+interface ChatRequest {
+  messages: UIMessage[];
+  system?: string; // System message forwarded from AssistantChatTransport
+  tools?: unknown; // Frontend tools forwarded from AssistantChatTransport
+  pageContext?: {
+    title?: string;
+    description?: string;
+    content?: string;
+    slug?: string;
+  };
+  provider?: AIProvider;
+  apiKey?: string;
+}
+
 export async function POST(req: Request) {
-  const {
-    messages,
-    system,
-    pageContext,
-    provider,
-    apiKey,
-  }: {
-    messages: UIMessage[];
-    system?: string; // System message forwarded from AssistantChatTransport
-    tools?: unknown; // Frontend tools forwarded from AssistantChatTransport
-    pageContext?: {
-      title?: string;
-      description?: string;
-      content?: string;
-      slug?: string;
-    };
-    provider?: "openai" | "gemini" | "intern";
-    apiKey?: string;
-  } = await req.json();
-
-  // Check if API key is provided (not required for intern provider)
-  if (provider !== "intern" && (!apiKey || apiKey.trim() === "")) {
-    return Response.json(
-      {
-        error:
-          "API key is required. Please configure your API key in the settings.",
-      },
-      { status: 400 },
-    );
-  }
-
   try {
+    const {
+      messages,
+      system,
+      pageContext,
+      provider = "openai", // Default to OpenAI
+      apiKey,
+    }: ChatRequest = await req.json();
+
+    // Validate API key for providers that require it
+    if (requiresApiKey(provider) && (!apiKey || apiKey.trim() === "")) {
+      return Response.json(
+        {
+          error:
+            "API key is required. Please configure your API key in the settings.",
+        },
+        { status: 400 },
+      );
+    }
+
     // Build system message with page context
-    let systemMessage =
-      system ||
-      `You are a helpful AI assistant for a documentation website. 
-    You can help users understand the documentation, answer questions about the content, 
-    and provide guidance on the topics covered in the docs. Be concise and helpful.`;
+    const systemMessage = buildSystemMessage(system, pageContext);
 
-    // Add current page context if available
-    if (pageContext?.content) {
-      systemMessage += `\n\n--- CURRENT PAGE CONTEXT ---\n`;
-      if (pageContext.title) {
-        systemMessage += `Page Title: ${pageContext.title}\n`;
-      }
-      if (pageContext.description) {
-        systemMessage += `Page Description: ${pageContext.description}\n`;
-      }
-      if (pageContext.slug) {
-        systemMessage += `Page URL: /docs/${pageContext.slug}\n`;
-      }
-      systemMessage += `Page Content:\n${pageContext.content}`;
-      systemMessage += `\n--- END OF CONTEXT ---\n\nWhen users ask about "this page", "current page", or refer to the content they're reading, use the above context to provide accurate answers. You can summarize, explain, or answer specific questions about the current page content.`;
-    }
+    // Get AI model instance based on provider
+    const model = getModel(provider, apiKey);
 
-    // Select model based on provider
-    let model;
-    if (provider === "gemini") {
-      const customGoogle = createGoogleGenerativeAI({
-        apiKey: apiKey,
-      });
-      model = customGoogle("models/gemini-2.0-flash");
-    } else if (provider === "intern") {
-      const intern = createOpenAICompatible({
-        name: "intern",
-        baseURL: "https://chat.intern-ai.org.cn/api/v1/",
-        apiKey: process.env.INTERN_KEY,
-      });
-      model = intern("intern-s1");
-    } else {
-      // Default to OpenAI
-      const customOpenAI = createOpenAI({
-        apiKey: apiKey,
-      });
-      model = customOpenAI("gpt-4.1-nano");
-    }
-
+    // Generate streaming response
     const result = streamText({
       model: model,
       system: systemMessage,
@@ -93,6 +56,12 @@ export async function POST(req: Request) {
     return result.toUIMessageStreamResponse();
   } catch (error) {
     console.error("Chat API error:", error);
+
+    // Handle specific model creation errors
+    if (error instanceof Error && error.message.includes("API key")) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+
     return Response.json(
       { error: "Failed to process chat request" },
       { status: 500 },

--- a/app/components/DocsAssistant.tsx
+++ b/app/components/DocsAssistant.tsx
@@ -53,7 +53,9 @@ function DocsAssistantInner({ pageContext }: DocsAssistantProps) {
         const currentApiKey =
           currentProvider === "openai"
             ? openaiApiKeyRef.current
-            : geminiApiKeyRef.current;
+            : currentProvider === "gemini"
+              ? geminiApiKeyRef.current
+              : ""; // intern provider doesn't need API key
 
         console.log("[DocsAssistant] useChat body function called with:", {
           provider: currentProvider,
@@ -118,9 +120,14 @@ interface AssistantErrorState {
 
 function deriveAssistantError(
   err: unknown,
-  provider: "openai" | "gemini",
+  provider: "openai" | "gemini" | "intern",
 ): AssistantErrorState {
-  const providerLabel = provider === "gemini" ? "Google Gemini" : "OpenAI";
+  const providerLabel =
+    provider === "gemini"
+      ? "Google Gemini"
+      : provider === "intern"
+        ? "Intern-AI"
+        : "OpenAI";
   const fallback: AssistantErrorState = {
     message:
       "The assistant couldn't complete that request. Please try again later.",
@@ -176,14 +183,16 @@ function deriveAssistantError(
 
   let showSettingsCTA = false;
 
+  // For intern provider, don't show settings CTA for API key related errors
   if (
-    statusCode === 400 ||
-    statusCode === 401 ||
-    statusCode === 403 ||
-    normalized.includes("api key") ||
-    normalized.includes("apikey") ||
-    normalized.includes("missing key") ||
-    normalized.includes("unauthorized")
+    provider !== "intern" &&
+    (statusCode === 400 ||
+      statusCode === 401 ||
+      statusCode === 403 ||
+      normalized.includes("api key") ||
+      normalized.includes("apikey") ||
+      normalized.includes("missing key") ||
+      normalized.includes("unauthorized"))
   ) {
     showSettingsCTA = true;
   }

--- a/app/components/assistant-ui/SettingsDialog.tsx
+++ b/app/components/assistant-ui/SettingsDialog.tsx
@@ -51,9 +51,13 @@ export const SettingsDialog = ({
             <RadioGroup
               value={provider}
               onValueChange={(value) =>
-                setProvider(value as "openai" | "gemini")
+                setProvider(value as "openai" | "gemini" | "intern")
               }
             >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="intern" id="intern" />
+                <Label htmlFor="intern">InternS1 (Free)</Label>
+              </div>
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="openai" id="openai" />
                 <Label htmlFor="openai">OpenAI</Label>
@@ -88,6 +92,15 @@ export const SettingsDialog = ({
                 value={geminiApiKey}
                 onChange={(e) => setGeminiApiKey(e.target.value)}
               />
+            </div>
+          )}
+
+          {provider === "intern" && (
+            <div className="space-y-2">
+              <div className="text-sm text-muted-foreground">
+                感谢上海AILab的书生大模型对本项目的算力支持，Intern-AI
+                模型已预配置，无需提供 API Key。
+              </div>
             </div>
           )}
         </div>

--- a/app/components/assistant-ui/assistant-modal.tsx
+++ b/app/components/assistant-ui/assistant-modal.tsx
@@ -21,7 +21,7 @@ export const AssistantModal: FC<AssistantModalProps> = ({
 }) => {
   return (
     <AssistantModalPrimitive.Root>
-      <AssistantModalPrimitive.Anchor className="aui-root aui-modal-anchor fixed right-4 bottom-4 size-11">
+      <AssistantModalPrimitive.Anchor className="aui-root aui-modal-anchor fixed right-4 bottom-4 size-14">
         <AssistantModalPrimitive.Trigger asChild>
           <AssistantModalButton />
         </AssistantModalPrimitive.Trigger>
@@ -59,12 +59,12 @@ const AssistantModalButton = forwardRef<
     >
       <BotIcon
         data-state={state}
-        className="aui-modal-button-closed-icon absolute size-6 transition-all data-[state=closed]:scale-100 data-[state=closed]:rotate-0 data-[state=open]:scale-0 data-[state=open]:rotate-90"
+        className="aui-modal-button-closed-icon absolute !size-7 transition-all data-[state=closed]:scale-100 data-[state=closed]:rotate-0 data-[state=open]:scale-0 data-[state=open]:rotate-90"
       />
 
       <ChevronDownIcon
         data-state={state}
-        className="aui-modal-button-open-icon absolute size-6 transition-all data-[state=closed]:scale-0 data-[state=closed]:-rotate-90 data-[state=open]:scale-100 data-[state=open]:rotate-0"
+        className="aui-modal-button-open-icon absolute !size-7 transition-all data-[state=closed]:scale-0 data-[state=closed]:-rotate-90 data-[state=open]:scale-100 data-[state=open]:rotate-0"
       />
       <span className="aui-sr-only sr-only">{tooltip}</span>
     </TooltipIconButton>

--- a/app/components/assistant-ui/thread.tsx
+++ b/app/components/assistant-ui/thread.tsx
@@ -268,9 +268,19 @@ const Composer: FC<ComposerProps> = ({
   onClearError,
 }) => {
   const { provider, openaiApiKey, geminiApiKey } = useAssistantSettings();
-  const activeKey = provider === "openai" ? openaiApiKey : geminiApiKey;
-  const hasActiveKey = activeKey.trim().length > 0;
-  const providerLabel = provider === "gemini" ? "Google Gemini" : "OpenAI";
+  const activeKey =
+    provider === "openai"
+      ? openaiApiKey
+      : provider === "gemini"
+        ? geminiApiKey
+        : "";
+  const hasActiveKey = provider === "intern" || activeKey.trim().length > 0;
+  const providerLabel =
+    provider === "gemini"
+      ? "Google Gemini"
+      : provider === "intern"
+        ? "Intern-AI"
+        : "OpenAI";
 
   const handleOpenSettings = useCallback(() => {
     onClearError?.();

--- a/app/components/assistant-ui/thread.tsx
+++ b/app/components/assistant-ui/thread.tsx
@@ -288,7 +288,7 @@ const Composer: FC<ComposerProps> = ({
   }, [onClearError, onOpenChange]);
 
   return (
-    <div className="aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 overflow-visible rounded-t-3xl pb-4 md:pb-6">
+    <div className="aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 overflow-visible rounded-t-3xl bg-white pb-4 md:pb-6">
       <ThreadScrollToBottom />
       <ThreadPrimitive.Empty>
         <ThreadWelcomeSuggestions />

--- a/app/hooks/useAssistantSettings.tsx
+++ b/app/hooks/useAssistantSettings.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type { ReactNode } from "react";
 
-type Provider = "openai" | "gemini";
+type Provider = "openai" | "gemini" | "intern";
 
 interface AssistantSettingsState {
   provider: Provider;
@@ -45,7 +45,12 @@ const parseStoredSettings = (raw: string | null): AssistantSettingsState => {
   try {
     const parsed = JSON.parse(raw) as Partial<AssistantSettingsState>;
     return {
-      provider: parsed.provider === "gemini" ? "gemini" : "openai",
+      provider:
+        parsed.provider === "gemini"
+          ? "gemini"
+          : parsed.provider === "intern"
+            ? "intern"
+            : "openai",
       openaiApiKey:
         typeof parsed.openaiApiKey === "string" ? parsed.openaiApiKey : "",
       geminiApiKey:

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -1,0 +1,43 @@
+import { createOpenAIModel } from "./providers/openai";
+import { createGeminiModel } from "./providers/gemini";
+import { createInternModel } from "./providers/intern";
+
+export type AIProvider = "openai" | "gemini" | "intern";
+
+/**
+ * Model factory that returns the appropriate AI model based on provider
+ * @param provider - The AI provider to use
+ * @param apiKey - API key (not required for intern provider)
+ * @returns Configured AI model instance
+ */
+export function getModel(provider: AIProvider, apiKey?: string) {
+  switch (provider) {
+    case "openai":
+      if (!apiKey || apiKey.trim() === "") {
+        throw new Error("OpenAI API key is required");
+      }
+      return createOpenAIModel(apiKey);
+
+    case "gemini":
+      if (!apiKey || apiKey.trim() === "") {
+        throw new Error("Gemini API key is required");
+      }
+      return createGeminiModel(apiKey);
+
+    case "intern":
+      // Intern provider doesn't need API key from user
+      return createInternModel();
+
+    default:
+      throw new Error(`Unsupported AI provider: ${provider}`);
+  }
+}
+
+/**
+ * Check if the given provider requires an API key from the user
+ * @param provider - The AI provider to check
+ * @returns True if API key is required, false otherwise
+ */
+export function requiresApiKey(provider: AIProvider): boolean {
+  return provider !== "intern";
+}

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -5,10 +5,10 @@ import { createInternModel } from "./providers/intern";
 export type AIProvider = "openai" | "gemini" | "intern";
 
 /**
- * Model factory that returns the appropriate AI model based on provider
- * @param provider - The AI provider to use
- * @param apiKey - API key (not required for intern provider)
- * @returns Configured AI model instance
+ * Model工厂 用于返回对应的 AI 模型实例
+ * @param provider - 要用的provider
+ * @param apiKey - API key (intern provider不需要用户提供 API key)
+ * @returns 配置好的 AI 模型实例
  */
 export function getModel(provider: AIProvider, apiKey?: string) {
   switch (provider) {
@@ -25,7 +25,7 @@ export function getModel(provider: AIProvider, apiKey?: string) {
       return createGeminiModel(apiKey);
 
     case "intern":
-      // Intern provider doesn't need API key from user
+      // Intern 书生模型不需要用户提供 API key
       return createInternModel();
 
     default:
@@ -34,9 +34,9 @@ export function getModel(provider: AIProvider, apiKey?: string) {
 }
 
 /**
- * Check if the given provider requires an API key from the user
- * @param provider - The AI provider to check
- * @returns True if API key is required, false otherwise
+ * 检查指定的提供者是否需要用户提供 API key
+ * @param provider - 要检查的provider
+ * @returns 如果需要 API key，返回 true，否则返回 false
  */
 export function requiresApiKey(provider: AIProvider): boolean {
   return provider !== "intern";

--- a/lib/ai/prompt.ts
+++ b/lib/ai/prompt.ts
@@ -18,9 +18,9 @@ export function buildSystemMessage(
   // 默认系统消息
   let systemMessage =
     customSystem ||
-    `You are a helpful AI assistant for a documentation website. 
-    You can help users understand the documentation, answer questions about the content, 
-    and provide guidance on the topics covered in the docs. Be concise and helpful.`;
+    `You are a helpful AI assistant for a documentation website.
+    Always respond in the same language as the user's question: if the user asks in 中文, answer in 中文; if the user asks in English, answer in English.
+    You can help users understand the documentation, answer questions about the content, and provide guidance on the topics covered in the docs. Be concise and helpful.`;
 
   // 如果当前页面上下文可用，则添加到系统消息中
   if (pageContext?.content) {

--- a/lib/ai/prompt.ts
+++ b/lib/ai/prompt.ts
@@ -1,0 +1,46 @@
+interface PageContext {
+  title?: string;
+  description?: string;
+  content?: string;
+  slug?: string;
+}
+
+/**
+ * Build system message with page context for AI assistant
+ * @param customSystem - Custom system message (optional)
+ * @param pageContext - Current page context (optional)
+ * @returns Complete system message string
+ */
+export function buildSystemMessage(
+  customSystem?: string,
+  pageContext?: PageContext,
+): string {
+  // Default system message for documentation assistant
+  let systemMessage =
+    customSystem ||
+    `You are a helpful AI assistant for a documentation website. 
+    You can help users understand the documentation, answer questions about the content, 
+    and provide guidance on the topics covered in the docs. Be concise and helpful.`;
+
+  // Add current page context if available
+  if (pageContext?.content) {
+    systemMessage += `\n\n--- CURRENT PAGE CONTEXT ---\n`;
+
+    if (pageContext.title) {
+      systemMessage += `Page Title: ${pageContext.title}\n`;
+    }
+
+    if (pageContext.description) {
+      systemMessage += `Page Description: ${pageContext.description}\n`;
+    }
+
+    if (pageContext.slug) {
+      systemMessage += `Page URL: /docs/${pageContext.slug}\n`;
+    }
+
+    systemMessage += `Page Content:\n${pageContext.content}`;
+    systemMessage += `\n--- END OF CONTEXT ---\n\nWhen users ask about "this page", "current page", or refer to the content they're reading, use the above context to provide accurate answers. You can summarize, explain, or answer specific questions about the current page content.`;
+  }
+
+  return systemMessage;
+}

--- a/lib/ai/prompt.ts
+++ b/lib/ai/prompt.ts
@@ -6,23 +6,23 @@ interface PageContext {
 }
 
 /**
- * Build system message with page context for AI assistant
- * @param customSystem - Custom system message (optional)
- * @param pageContext - Current page context (optional)
- * @returns Complete system message string
+ * 构建系统消息，包含页面上下文
+ * @param customSystem - 自定义系统消息 (可选)
+ * @param pageContext - 当前页面上下文 (可选)
+ * @returns 完整的系统消息字符串
  */
 export function buildSystemMessage(
   customSystem?: string,
   pageContext?: PageContext,
 ): string {
-  // Default system message for documentation assistant
+  // 默认系统消息
   let systemMessage =
     customSystem ||
     `You are a helpful AI assistant for a documentation website. 
     You can help users understand the documentation, answer questions about the content, 
     and provide guidance on the topics covered in the docs. Be concise and helpful.`;
 
-  // Add current page context if available
+  // 如果当前页面上下文可用，则添加到系统消息中
   if (pageContext?.content) {
     systemMessage += `\n\n--- CURRENT PAGE CONTEXT ---\n`;
 

--- a/lib/ai/providers/gemini.ts
+++ b/lib/ai/providers/gemini.ts
@@ -1,0 +1,15 @@
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+
+/**
+ * Create Google Gemini model instance
+ * @param apiKey - Google Gemini API key provided by user
+ * @returns Configured Gemini model instance
+ */
+export function createGeminiModel(apiKey: string) {
+  const customGoogle = createGoogleGenerativeAI({
+    apiKey: apiKey,
+  });
+
+  // Use the specific model configured for this project
+  return customGoogle("models/gemini-2.0-flash");
+}

--- a/lib/ai/providers/intern.ts
+++ b/lib/ai/providers/intern.ts
@@ -1,0 +1,17 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+
+/**
+ * Create Intern-AI model instance
+ * Uses environment variable INTERN_KEY for API key
+ * @returns Configured Intern-AI model instance
+ */
+export function createInternModel() {
+  const intern = createOpenAICompatible({
+    name: "intern",
+    baseURL: "https://chat.intern-ai.org.cn/api/v1/",
+    apiKey: process.env.INTERN_KEY,
+  });
+
+  // Use the specific model configured for this project
+  return intern("intern-s1");
+}

--- a/lib/ai/providers/openai.ts
+++ b/lib/ai/providers/openai.ts
@@ -1,0 +1,15 @@
+import { createOpenAI } from "@ai-sdk/openai";
+
+/**
+ * Create OpenAI model instance
+ * @param apiKey - OpenAI API key provided by user
+ * @returns Configured OpenAI model instance
+ */
+export function createOpenAIModel(apiKey: string) {
+  const customOpenAI = createOpenAI({
+    apiKey: apiKey,
+  });
+
+  // Use the specific model configured for this project
+  return customOpenAI("gpt-4.1-nano");
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@ai-sdk/google": "^2.0.14",
     "@ai-sdk/openai": "^2.0.32",
+    "@ai-sdk/openai-compatible": "^1.0.19",
     "@ai-sdk/react": "^2.0.48",
     "@assistant-ui/react": "^0.11.14",
     "@assistant-ui/react-ai-sdk": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       "@ai-sdk/openai":
         specifier: ^2.0.32
         version: 2.0.32(zod@4.1.11)
+      "@ai-sdk/openai-compatible":
+        specifier: ^1.0.19
+        version: 1.0.19(zod@4.1.11)
       "@ai-sdk/react":
         specifier: ^2.0.48
         version: 2.0.48(react@19.1.1)(zod@4.1.11)
@@ -208,6 +211,15 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  "@ai-sdk/openai-compatible@1.0.19":
+    resolution:
+      {
+        integrity: sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   "@ai-sdk/openai@2.0.32":
     resolution:
       {
@@ -216,6 +228,15 @@ packages:
     engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4
+
+  "@ai-sdk/provider-utils@3.0.10":
+    resolution:
+      {
+        integrity: sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   "@ai-sdk/provider-utils@3.0.9":
     resolution:
@@ -8409,10 +8430,23 @@ snapshots:
       "@ai-sdk/provider-utils": 3.0.9(zod@4.1.11)
       zod: 4.1.11
 
+  "@ai-sdk/openai-compatible@1.0.19(zod@4.1.11)":
+    dependencies:
+      "@ai-sdk/provider": 2.0.0
+      "@ai-sdk/provider-utils": 3.0.10(zod@4.1.11)
+      zod: 4.1.11
+
   "@ai-sdk/openai@2.0.32(zod@4.1.11)":
     dependencies:
       "@ai-sdk/provider": 2.0.0
       "@ai-sdk/provider-utils": 3.0.9(zod@4.1.11)
+      zod: 4.1.11
+
+  "@ai-sdk/provider-utils@3.0.10(zod@4.1.11)":
+    dependencies:
+      "@ai-sdk/provider": 2.0.0
+      "@standard-schema/spec": 1.0.0
+      eventsource-parser: 3.0.6
       zod: 4.1.11
 
   "@ai-sdk/provider-utils@3.0.9(zod@4.1.11)":


### PR DESCRIPTION
现在AI助手默认使用免费的InternS1模型，不需要配置Key也能与文档AI对话了。

主要改动点：
1. 解耦了AI route的代码，现在route只专注于Post /api/chat的接口代码，AI相关的代码被解耦到lib/ai下，拆分出了model切换，model配置，prompt配置三个文件，便于后续AI功能拓展开发的代码复用。
2. 引入了ai-sdk/openai-compatible以增加对chatAPI兼容的外部模型的支持，provider下新增Intern model
3. AI助手增加书生大模型的使用。

效果：
<img width="1906" height="910" alt="image" src="https://github.com/user-attachments/assets/b259a2d2-5061-4cdf-b492-f43604de9587" />
