### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/app/docs/[...slug]/page.tsx
+++ b/app/docs/[...slug]/page.tsx
@@ -17,11 +17,17 @@ import path from "path";
 
 // Extract clean text content from MDX
 function extractTextFromMDX(content: string): string {
-  return content
+  let text = content
     .replace(/^---[\s\S]*?---/m, "") // Remove frontmatter
     .replace(/```[\s\S]*?```/g, "") // Remove code blocks
-    .replace(/`([^`]+)`/g, "$1") // Remove inline code
-    .replace(/<[^>]+>/g, "") // Remove HTML/MDX tags
+    .replace(/`([^`]+)`/g, "$1"); // Remove inline code
+  // Remove HTML/MDX tags recursively to prevent incomplete multi-character sanitization
+  let prevText;
+  do {
+    prevText = text;
+    text = text.replace(/<[^>]+>/g, "");
+  } while (text !== prevText);
+  return text
     .replace(/\*\*([^*]+)\*\*/g, "$1") // Remove bold
     .replace(/\*([^*]+)\*/g, "$1") // Remove italic
     .replace(/#{1,6}\s+/g, "") // Remove headers


### PR DESCRIPTION
Potential fix for [https://github.com/InvolutionHell/involutionhell.github.io/security/code-scanning/3](https://github.com/InvolutionHell/involutionhell.github.io/security/code-scanning/3)

To fix this problem, we need to ensure all HTML/MDX tags are thoroughly removed, including cases where consecutive characters produce nested or re-emerging unsafe constructs after initial replacement (such as `<script>` and similar patterns). The ideal approach is to repeatedly apply the tag-removal regular expression until no more tags are detected, so that constructs like `<<script>>` are reduced to an empty string or harmless content. 

Specifically, in the `extractTextFromMDX` function in app/docs/[...slug]/page.tsx, we should change the `.replace(/<[^>]+>/g, "")` on line 24 to a loop that repeatedly applies it until no more changes occur. No new libraries are required if we use this approach.

#### Required changes:
- On line 24, replace the single `.replace()` call for HTML/MDX tags with a loop that continues replacing as long as matches are found.
- This may require extracting that step out of the chain for clarity, or using a helper function within `extractTextFromMDX`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
