### PR TITLE
docs: add agent and llm workflow guides

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,36 @@
+# AGENT Guidelines
+
+Welcome! This repository hosts the Involution Hell documentation site, built with Next.js App Router, Fumadocs UI, TypeScript, and Tailwind CSS. Follow the instructions below whenever you contribute changes.
+
+## General workflow
+
+- Prefer `pnpm` for all Node.js commands (`pnpm install`, `pnpm dev`, `pnpm build`, etc.).
+- Keep changes focused and provide helpful descriptions in commits and PR messages.
+- When adding dependencies, ensure they are compatible with Node.js 18+.
+
+## Coding standards
+
+- Follow existing patterns in the codebase; align new components with the established structure under `app/` and `components/`.
+- Use TypeScript (`.ts` / `.tsx`) and Tailwind CSS utility classes for styling unless a file already uses a different approach.
+- Avoid unnecessary abstractions; keep components small, composable, and accessible.
+- Do not wrap imports in `try/catch` blocks.
+
+## Documentation & content
+
+- All documentation lives under `app/docs/` (folder-as-book). Each Markdown/MDX file **must** retain a frontmatter block with at least a `title`.
+- Place images referenced by a document inside the document’s sibling `*.assets/` folder. Use the provided image migration scripts if needed.
+- Prefer relative links within the docs unless cross-referencing an external resource.
+
+## Testing & validation
+
+- Run relevant scripts before submitting changes. Common checks include:
+  - `pnpm dev` for local verification.
+  - `pnpm build` for production validation when you touch runtime logic.
+  - `pnpm lint:images` when you add or move media assets.
+
+## PR expectations
+
+- Summarize user-facing changes clearly.
+- Mention any new scripts, configuration, or docs that reviewers should be aware of.
+
+For additional details, consult `README.md` and `CONTRIBUTING.md`.

--- a/LLM.md
+++ b/LLM.md
@@ -1,0 +1,43 @@
+# LLM Playbook
+
+This guide distills the key information an autonomous agent or ChatGPT-style assistant needs when working in this repository.
+
+## Project summary
+
+- **Stack:** Next.js (App Router) + TypeScript + Tailwind CSS + Fumadocs UI.
+- **Purpose:** Collaborative knowledge base for students, served from `app/docs/` content.
+- **Configs of interest:**
+  - `source.config.ts` – Fumadocs sources and structure.
+  - `mdx-components.tsx` – custom MDX components available to docs.
+  - `components/` – reusable UI building blocks.
+
+## Common tasks
+
+### Updating content
+
+1. Edit or add Markdown/MDX files under `app/docs/`.
+2. Preserve the frontmatter block with at least `title` and include optional metadata (`description`, `date`, `tags`).
+3. Place referenced media inside `<doc>.assets/` and run `pnpm lint:images` if assets change.
+
+### Implementing UI logic
+
+1. Add shared pieces to `components/` or page-specific pieces under the relevant `app/` route folder.
+2. Use Tailwind utilities for styling; follow existing responsive patterns.
+3. Ensure server/client boundaries are respected (declare `"use client"` only when necessary).
+
+## Useful commands
+
+- `pnpm install` – install dependencies (Node.js 18+ required).
+- `pnpm dev` – start the development server at <http://localhost:3000>.
+- `pnpm build` – run the production build (use when changing runtime code or config).
+- `pnpm lint:images` – validate documentation images.
+
+## Review checklist
+
+- [ ] Frontmatter present on new/edited docs.
+- [ ] Assets live beside their documents.
+- [ ] Components match surrounding code style and naming.
+- [ ] Necessary scripts/tests executed and mentioned in the report.
+- [ ] PR summary explains user-visible changes and follow-up steps if any.
+
+For deeper details, read `README.md`, `README.en.md`, and `CONTRIBUTING.md`.


### PR DESCRIPTION
## Summary
- add a repository-wide `AGENT.md` with workflow, coding, and documentation guidelines
- introduce `LLM.md` playbook summarizing stack details, common tasks, and review checklist for assistants

## Testing
- pnpm migrate:images
- pnpm lint:images

------
https://chatgpt.com/codex/tasks/task_e_68efb546e7f883239ea26f311a3c875e