### PR TITLE
Potential fix for code scanning alert no. 4: Clear text storage of sensitive information

### DIFF
--- a/app/hooks/useAssistantSettings.tsx
+++ b/app/hooks/useAssistantSettings.tsx
@@ -10,6 +10,89 @@ import {
 } from "react";
 import type { ReactNode } from "react";
 
+// --- Encryption helpers using Web Crypto API, with a placeholder key ---
+// In a real app, get the passphrase from the user. Here, use a placeholder.
+const ENCRYPTION_KEY_PASSPHRASE = "replace-this-passphrase"; // TODO: Prompt user!
+const ENCRYPTION_SALT = "assistant-settings-salt"; // static salt (insecure, for demo)
+
+async function getKeyFromPassphrase(passphrase: string) {
+  const enc = new TextEncoder();
+  const keyMaterial = await window.crypto.subtle.importKey(
+    "raw",
+    enc.encode(passphrase),
+    { name: "PBKDF2" },
+    false,
+    ["deriveKey"]
+  );
+  return window.crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: enc.encode(ENCRYPTION_SALT),
+      iterations: 100000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+// encrypt text, return base64(iv):base64(ciphertext)
+export async function encryptString(plainText: string, passphrase: string): Promise<string> {
+  const iv = window.crypto.getRandomValues(new Uint8Array(12));
+  const key = await getKeyFromPassphrase(passphrase);
+  const enc = new TextEncoder();
+  const ciphertext = await window.crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    enc.encode(plainText)
+  );
+  // Pack IV and ciphertext into a base64 string
+  return (
+    btoa(String.fromCharCode(...iv)) +
+    ":" +
+    btoa(String.fromCharCode(...new Uint8Array(ciphertext)))
+  );
+}
+
+// decrypt base64(iv):base64(ciphertext)
+export async function decryptString(cipherText: string, passphrase: string): Promise<string> {
+  if (!cipherText.includes(":")) return "";
+  const [ivPart, cipherPart] = cipherText.split(":");
+  const iv = Uint8Array.from(atob(ivPart), c => c.charCodeAt(0));
+  const data = Uint8Array.from(atob(cipherPart), c => c.charCodeAt(0));
+  const key = await getKeyFromPassphrase(passphrase);
+  const decrypted = await window.crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    data
+  );
+  return new TextDecoder().decode(decrypted);
+}
+
+// Returns a settings object with encrypted keys, for storage.
+export async function encryptSettings(settings: AssistantSettingsState, passphrase: string): Promise<Omit<AssistantSettingsState, "openaiApiKey" | "geminiApiKey"> & { openaiApiKey: string, geminiApiKey: string }> {
+  return {
+    provider: settings.provider,
+    openaiApiKey: settings.openaiApiKey ? await encryptString(settings.openaiApiKey, passphrase) : "",
+    geminiApiKey: settings.geminiApiKey ? await encryptString(settings.geminiApiKey, passphrase) : "",
+  };
+}
+
+// Returns a settings object with decrypted keys, for in-memory use.
+export async function decryptSettings(stored: AssistantSettingsState, passphrase: string): Promise<AssistantSettingsState> {
+  return {
+    provider: stored.provider,
+    openaiApiKey: stored.openaiApiKey
+      ? await decryptString(stored.openaiApiKey, passphrase)
+      : "",
+    geminiApiKey: stored.geminiApiKey
+      ? await decryptString(stored.geminiApiKey, passphrase)
+      : "",
+  };
+}
+
 type Provider = "openai" | "gemini" | "intern";
 
 interface AssistantSettingsState {
@@ -79,42 +162,67 @@ export const AssistantSettingsProvider = ({
 }: {
   children: ReactNode;
 }) => {
-  const [settings, setSettings] = useState<AssistantSettingsState>(() =>
-    readStoredSettings(),
-  );
+  // Need to initialize state async due to decryption; use blank, then load in useEffect.
+  const [settings, setSettings] = useState<AssistantSettingsState>({ ...defaultSettings });
 
+  // Encrypt and store the settings whenever they change
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
-
-    try {
-      window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
-    } catch (error) {
-      console.error("Failed to save assistant settings to localStorage", error);
-    }
+    (async () => {
+      try {
+        // Only store encrypted API keys in localStorage
+        const encrypted = await encryptSettings(settings, ENCRYPTION_KEY_PASSPHRASE);
+        window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(encrypted));
+      } catch (error) {
+        console.error("Failed to save assistant settings to localStorage", error);
+      }
+    })();
   }, [settings]);
 
+  // On mount, load encrypted settings from localStorage and decrypt
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
+    (async () => {
+      const raw = window.localStorage.getItem(SETTINGS_KEY);
+      const parsed = parseStoredSettings(raw);
+      const decrypted = await decryptSettings(parsed, ENCRYPTION_KEY_PASSPHRASE);
+      setSettings(decrypted);
+    })();
+  }, []);
 
+  // Storage event for cross-tab sync. Decrypt new values!
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
     const handleStorage = (event: StorageEvent) => {
       if (event.key !== SETTINGS_KEY) {
         return;
       }
-
-      setSettings(parseStoredSettings(event.newValue));
+      (async () => {
+        const parsed = parseStoredSettings(event.newValue);
+        const decrypted = await decryptSettings(parsed, ENCRYPTION_KEY_PASSPHRASE);
+        setSettings(decrypted);
+      })();
     };
-
     window.addEventListener("storage", handleStorage);
     return () => window.removeEventListener("storage", handleStorage);
   }, []);
 
+  // Refresh from storage (decrypt)
   const refreshFromStorage = useCallback(() => {
-    const latestSettings = readStoredSettings();
-    setSettings(latestSettings);
+    if (typeof window === "undefined") {
+      return;
+    }
+    (async () => {
+      const latest = readStoredSettings();
+      const decrypted = await decryptSettings(latest, ENCRYPTION_KEY_PASSPHRASE);
+      setSettings(decrypted);
+    })();
   }, []);
 
   const value = useMemo(


### PR DESCRIPTION
Potential fix for [https://github.com/InvolutionHell/involutionhell/security/code-scanning/4](https://github.com/InvolutionHell/involutionhell/security/code-scanning/4)

**General fix:**  
Sensitive information like API keys should never be persisted in localStorage in cleartext. You should either avoid storing these secrets at all, or encrypt them before saving them, storing only encrypted values in localStorage. Decryption should only occur in-memory when needed and with a key/password only the user knows.

**Best approach for the provided code:**  
The best way, without removing any existing functionality, is to encrypt the `openaiApiKey` and `geminiApiKey` fields before persisting and decrypt them after reading. One standard approach for browser environments is to use the Web Crypto API (`window.crypto.subtle`), as third-party modules like `crypto-js` are large and discouraged for new projects.

The general steps:
- Encrypt `openaiApiKey` and `geminiApiKey` (if present) before storage using a secret only the user knows (for example, a passphrase supplied by the user—not stored in localStorage).  
- Decrypt these fields after reading from storage.
- The encryption key cannot be hardcoded if this is to be secure; for demonstration, we may use a placeholder/environment value, but the user should be prompted to supply the passphrase on load.

**Code changes needed:**  
- Add encryption/decryption helper functions (using Web Crypto API).
- Modify the code in the useEffect that saves to localStorage (line 92) to store encrypted versions of the API keys.
- Modify the parsing code (in `parseStoredSettings` and related) to decrypt the keys when they are loaded.
- Add logic for the user to provide a passphrase/key (not shown in the snippet—must assume it's available in some form, such as a context or prompt).
- Add necessary async handling, as Web Crypto API is async.

*Given that only this file is accessible for modifications, the encryption/decryption helpers and modifications must be in `app/hooks/useAssistantSettings.tsx`.*

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
