### PR TITLE
修复前端明文传输了Key，会被攻击

### DIFF
--- a/app/hooks/useAssistantSettings.tsx
+++ b/app/hooks/useAssistantSettings.tsx
@@ -276,8 +276,12 @@ export const AssistantSettingsProvider = ({
 
   const refreshFromStorage = useCallback(() => {
     (async () => {
-      const s = await readStoredSettings();
-      setSettings(s);
+      try {
+        const s = await readStoredSettings();
+        setSettings(s);
+      } catch (error) {
+        console.error("Failed to refresh settings from storage:", error);
+      }
     })();
   }, []);
 


### PR DESCRIPTION
## 原因

* 目前 API Key 明文保存在 `localStorage`，风险较高（导出本地存储、磁盘快照、共享计算机等）。
* 在不改动后端的前提下，用浏览器侧口令加密可显著降低“意外泄露”的风险。
* 同时，解决 TS 与 WebCrypto 的类型不一致导致的报错（`deriveKey/encrypt/decrypt` 处）。
--- 
* 新增加密格式：`enc:v1:<base64(salt)>:<base64(iv)>:<base64(cipher)>`

  * `PBKDF2`: `iterations=310_000`, `hash=SHA-256`, `salt=16B`
  * `AES-GCM`: `key=256bit`, `iv=12B`
* 新增 Context API：

  * `setPassphrase(passphrase: string | null)`：设置/清空口令（**保存在 `sessionStorage`**，浏览器关闭即清空）
  * `hasPassphrase: boolean`：是否已设置口令
* 存取逻辑：

  * **写入**：若存在口令 → 加密后写到 `localStorage`；否则以明文写入（兼容旧行为）
  * **读取**：若检测到 `enc:v1:` 前缀 → 尝试用口令解密；无口令或失败 → 返回空字符串
* TS 修复：

  * 保证 `salt/iv` 的底层 `buffer` 为 **`ArrayBuffer`**（而非 `ArrayBufferLike`），统一标注为 `BufferSource`
  * 去除不可靠的 `instanceof` 检查，改用通用视图 `viewOf` 处理 `ArrayBuffer | ArrayBufferView`
  * 避免 `...` 展开大数组，提供安全的 Base64 编解码工具

## 小提示

* 本地加密用于**降低意外泄露风险**；对 **XSS** 无法提供强保证（拿到 JS 执行权即可读出明文）。
* 口令仅保存在 `sessionStorage`，关闭浏览器后清空，减少长期驻留风险。
* 不在 SSR 环境调用 `window.crypto`；所有加解密仅在客户端执行。