### PR TITLE
Fix Shiki language mapping for C++ snippets

### DIFF
--- a/app/docs/CommunityShare/Leetcode/142.环形链表II_translated.md
+++ b/app/docs/CommunityShare/Leetcode/142.环形链表II_translated.md
@@ -166,7 +166,7 @@ class Solution:
             a, b = a.next, b.next
         return b
 ```
-```C++
+```cpp
 class Solution {
 public:
     ListNode *detectCycle(ListNode *head) {

--- a/app/docs/CommunityShare/Leetcode/2309兼具大小写的最好英文字母_translated.md
+++ b/app/docs/CommunityShare/Leetcode/2309兼具大小写的最好英文字母_translated.md
@@ -43,7 +43,7 @@ class Solution:
         return ""
 ```
 
-```C++ Hash table
+```cpp Hash table
 class Solution {
 public:
     string greatestLetter(string s) {


### PR DESCRIPTION
## Summary
- Update Leetcode markdown solutions to use `cpp` code fences instead of `C++` to match the Shiki language bundle

## Testing
- Not run (pnpm not available in the environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69327392c46c8323830b6021275ce216)