### PR TITLE
Remove missing image references from linked list article

### DIFF
--- a/app/docs/CommunityShare/Leetcode/142.环形链表II_translated.md
+++ b/app/docs/CommunityShare/Leetcode/142.环形链表II_translated.md
@@ -133,17 +133,7 @@ abbrlink: e2c9cca9
 ### Complexity analysis：
 hour间复杂度 O(N) ：In the second encounter，慢pointer须走step数 a<a+b；First encounter中，慢pointer须走step数 a+b−x<a+b，in x 为双pointer重合点and环入口距离；therefore总体为线性复杂度；
 Spatial complexity O(1) ：双pointer使用常数大小的额外空间。
-<img src="../photos/circle link array 2/Picture1.png" alt="Picture1.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture2.png" alt="Picture2.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture3.png" alt="Picture3.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture4.png" alt="Picture4.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture5.png" alt="Picture5.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture6.png" alt="Picture6.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture7.png" alt="Picture7.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture8.png" alt="Picture8.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture9.png" alt="Picture9.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture10.png" alt="Picture10.png" width="50%" height="50%">
-<img src="../photos/circle link array 2/Picture11.png" alt="Picture11.png" width="50%" height="50%">
+
 
 
 
@@ -166,7 +156,7 @@ class Solution:
             a, b = a.next, b.next
         return b
 ```
-```C++
+```cpp
 class Solution {
 public:
     ListNode *detectCycle(ListNode *head) {

--- a/app/docs/CommunityShare/Leetcode/2309兼具大小写的最好英文字母_translated.md
+++ b/app/docs/CommunityShare/Leetcode/2309兼具大小写的最好英文字母_translated.md
@@ -43,7 +43,7 @@ class Solution:
         return ""
 ```
 
-```C++ Hash table
+```cpp Hash table
 class Solution {
 public:
     string greatestLetter(string s) {


### PR DESCRIPTION
## Summary
- Remove broken local image references from the linked list cycle article to satisfy image linting

## Testing
- Not run (pnpm not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69327392c46c8323830b6021275ce216)