### PR TITLE
feat: hide FloatWindow when all events deprecated and update ActivityTicker links

### DIFF
--- a/app/components/ActivityTicker.tsx
+++ b/app/components/ActivityTicker.tsx
@@ -37,31 +37,40 @@ export function ActivityTicker({ className }: ActivityTickerProps) {
     event: (typeof events)[number],
     keyPrefix: string,
     idx: number,
-  ) => (
-    <div
-      key={`${keyPrefix}-${event.name}-${idx}`}
-      className="flex items-center gap-4 whitespace-nowrap"
-    >
-      {idx === lastEventIndex ? (
-        <span className="bg-[#CC0000] text-white px-2 py-0.5 font-mono text-[10px] uppercase tracking-tighter shrink-0">
-          Update
-        </span>
-      ) : null}
-      <a
-        href={event.discord}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="font-sans text-xs font-bold uppercase tracking-widest hover:text-[#CC0000]"
+  ) => {
+    let href = event.discord;
+    if (event.deprecated) {
+      href =
+        event.playback ||
+        "https://involutionhell.com/docs/jobs/event-keynote/event-takeway";
+    }
+
+    return (
+      <div
+        key={`${keyPrefix}-${event.name}-${idx}`}
+        className="flex items-center gap-4 whitespace-nowrap"
       >
-        {event.name} —{" "}
-        {event.deprecated ? "Archives Available" : "Event Active"}
-      </a>
-      <span className="text-neutral-400 font-mono text-[10px]">&bull;</span>
-      <span className="font-mono text-[10px] text-neutral-500 uppercase">
-        Edition 1.0.0
-      </span>
-    </div>
-  );
+        {idx === lastEventIndex ? (
+          <span className="bg-[#CC0000] text-white px-2 py-0.5 font-mono text-[10px] uppercase tracking-tighter shrink-0">
+            Update
+          </span>
+        ) : null}
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-sans text-xs font-bold uppercase tracking-widest hover:text-[#CC0000]"
+        >
+          {event.name} —{" "}
+          {event.deprecated ? "Archives Available" : "Event Active"}
+        </a>
+        <span className="text-neutral-400 font-mono text-[10px]">&bull;</span>
+        <span className="font-mono text-[10px] text-neutral-500 uppercase">
+          Edition 1.0.0
+        </span>
+      </div>
+    );
+  };
 
   return (
     <div

--- a/app/components/float-window/FloatWindow.tsx
+++ b/app/components/float-window/FloatWindow.tsx
@@ -29,7 +29,6 @@ export function FloatWindow() {
   const pathname = usePathname();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isDismissed, setIsDismissed] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
 
   // 仅在首页 (/) 可见
   const isHomePage = pathname === "/";
@@ -73,7 +72,8 @@ export function FloatWindow() {
   const handleDismiss = useCallback(() => setIsDismissed(true), []);
   const handleToggle = useCallback(() => setIsCollapsed((prev) => !prev), []);
 
-  if (!isHomePage || isDismissed || !latestEvent) return null;
+  if (!isHomePage || isDismissed || !latestEvent || latestEvent.deprecated)
+    return null;
 
   const currentEvent = latestEvent;
 
@@ -91,8 +91,6 @@ export function FloatWindow() {
       )}
       style={position ? { left: position.x, top: position.y } : undefined}
       onPointerDown={handlePointerDown}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       {/* 极简折叠状态 */}
       {isCollapsed ? (


### PR DESCRIPTION
Modified `app/components/float-window/FloatWindow.tsx` to hide the component if the latest event is deprecated (which implies all events are deprecated due to sorting).
Modified `app/components/ActivityTicker.tsx` to use the `playback` URL or a fallback URL (`https://involutionhell.com/docs/jobs/event-keynote/event-takeway`) when an event is deprecated, instead of the Discord URL.
Verified logic with a temporary unit test and ran existing tests to ensure no regressions.
Linted and type-checked the changes.

---
*PR created automatically by Jules for task [6939529083496794611](https://jules.google.com/task/6939529083496794611) started by @longsizhuo*