### PR TITLE
feat(docs): CommunityShare 索引改为从 fumadocs source 自动生成（替代 #110）

### DIFF
--- a/app/components/CommunityShareIndex.tsx
+++ b/app/components/CommunityShareIndex.tsx
@@ -1,0 +1,134 @@
+import { source } from "@/lib/source";
+import Link from "next/link";
+
+/**
+ * CommunityShare 自动目录索引（Server Component，渲染在 /docs/CommunityShare/index.mdx 内）。
+ *
+ * 为什么需要这个组件：
+ * 原先 index.mdx 里的分类列表是人工维护的 Markdown，每次新增文章 / 新增分类都要顺手改索引，
+ * 实际上经常漏（main 上 index.mdx 少列了 Amazing-AI-Tools / Language / Leetcode / Life /
+ * Personal-Study-Notes 五个分类，还留着"身体健康"这种完全空的占位分类）。
+ * 改成 server 组件从 fumadocs `source.getPages()` 实时读目录树 → 文档增删后索引自动同步，
+ * 不再需要 #110 那种靠脚本定期重新生成 MDX 的方案（也就不需要引入 glob / gray-matter 依赖）。
+ *
+ * 设计：
+ * - 顶级分类 = CommunityShare 下的直属一级目录
+ * - 每个分类的标题：优先读该分类 index.mdx 的 frontmatter.title；没 index 就用目录名兜底
+ * - 分类内的文章按 title 字母排序，排除分类自己的 index.mdx（避免"点击进入自己"的死循环）
+ * - 翻译版（lang === "en" 或文件名以 .en 结尾）不出现在列表，统一走原文 URL，locale 由 cookie 切
+ * - 分类条目超过 INLINE_LIMIT (12) 时折叠显示："共 N 篇 → 进入分类" 单行链接，
+ *   避免 Leetcode 这种几十上百篇的分类把页面顶爆
+ * - 完全不指向 "/docs/CommunityShare/<dir>" 硬拼 URL，全部走 page.url（fumadocs 已做 slug 规范化
+ *   和拼音转换，硬拼会漏掉 lib/source.ts 里 Leetcode 目录的 pinyin slug transform）
+ */
+
+type PageLike = ReturnType<typeof source.getPages>[number];
+
+const ROOT = "CommunityShare";
+const INLINE_LIMIT = 12;
+
+/** 判定一个页面是不是英文翻译版（不应出现在索引里） */
+function isEnglishVariant(page: PageLike): boolean {
+  const data = page.data as { lang?: string };
+  if (data.lang === "en") return true;
+  // 兜底：历史上有未加 lang frontmatter 的 .en.mdx 文件，靠文件名识别
+  return page.file.name.endsWith(".en");
+}
+
+/** 取页面 file.path 相对 ROOT 的第一级目录名，如 "CommunityShare/Geek/foo" → "Geek" */
+function firstSegmentUnderRoot(filePath: string): string | null {
+  const prefix = `${ROOT}/`;
+  if (!filePath.startsWith(prefix)) return null;
+  const rest = filePath.slice(prefix.length);
+  const slashIdx = rest.indexOf("/");
+  return slashIdx === -1 ? null : rest.slice(0, slashIdx);
+}
+
+export function CommunityShareIndex() {
+  const all = source.getPages();
+
+  // 第一步：筛出 CommunityShare 下的全部非英文版页面
+  const pages = all.filter(
+    (p) => p.file.path.startsWith(`${ROOT}/`) && !isEnglishVariant(p),
+  );
+
+  // 第二步：按第一级子目录分组（根目录的 index.mdx 本身 category=null，跳过）
+  const byCategory = new Map<string, PageLike[]>();
+  for (const page of pages) {
+    const category = firstSegmentUnderRoot(page.file.path);
+    if (!category) continue;
+    const bucket = byCategory.get(category) ?? [];
+    bucket.push(page);
+    byCategory.set(category, bucket);
+  }
+
+  // 第三步：构造渲染所需的 view-model，并按分类名排序
+  const categories = [...byCategory.entries()]
+    .map(([dirName, catPages]) => {
+      // 分类自己的 index.mdx（若存在）
+      const categoryIndex = catPages.find(
+        (p) =>
+          p.file.dirname === `${ROOT}/${dirName}` && p.file.name === "index",
+      );
+      const displayTitle = categoryIndex?.data.title ?? dirName;
+      const categoryUrl = categoryIndex?.url ?? `/docs/${ROOT}/${dirName}`;
+
+      // 内容条目 = 排除分类 index 本身
+      const entries = catPages
+        .filter((p) => p !== categoryIndex)
+        .sort((a, b) => a.data.title.localeCompare(b.data.title, "zh-Hans-CN"));
+
+      return {
+        dirName,
+        displayTitle,
+        categoryUrl,
+        entries,
+      };
+    })
+    .sort((a, b) => a.displayTitle.localeCompare(b.displayTitle, "zh-Hans-CN"));
+
+  if (categories.length === 0) {
+    // 兜底：理论上不会走到，但避免开发期目录清空时整个页面报错
+    return (
+      <p className="text-sm text-neutral-500">暂无分享内容，期待你的投稿！</p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {categories.map((cat) => (
+        <section key={cat.dirName}>
+          <h2 className="text-xl font-bold mb-3">
+            <Link href={cat.categoryUrl} className="hover:underline">
+              {cat.displayTitle}
+            </Link>
+            <span className="ml-2 text-xs font-normal text-neutral-500">
+              ({cat.entries.length} 篇)
+            </span>
+          </h2>
+          {cat.entries.length > INLINE_LIMIT ? (
+            // 超过阈值：折叠显示，避免 Leetcode 这种分类把页面顶爆
+            <p className="text-sm text-neutral-600 dark:text-neutral-400">
+              <Link
+                href={cat.categoryUrl}
+                className="text-[var(--color-fd-primary)] hover:underline"
+              >
+                查看全部 {cat.entries.length} 篇 →
+              </Link>
+            </p>
+          ) : (
+            <ul className="list-disc pl-6 space-y-1">
+              {cat.entries.map((p) => (
+                <li key={p.url}>
+                  <Link href={p.url} className="hover:underline">
+                    {p.data.title}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/app/docs/CommunityShare/index.mdx
+++ b/app/docs/CommunityShare/index.mdx
@@ -4,33 +4,12 @@ date: "2025-09-18"
 docId: sfzt30mtx0jsuv6esnpm3w8y
 ---
 
+import { CommunityShareIndex } from "@/app/components/CommunityShareIndex";
+
 欢迎来到群友分享板块！无论你是技术极客，还是热爱生活，都欢迎积极投稿！
 
 一篇微不足道的文章或许可以帮助一个迷茫的陌生人~
 
 > 转载文章请先联系原作者获取授权，谢谢！
 
-## 技术分享
-
-- [常用Markdown语法](/docs/CommunityShare/Geek/CommonUsedMarkdown)
-
-- [Git入门操作指南-程序员必会的git小技巧](/docs/CommunityShare/Geek/git101)
-
-- [用闲置树莓派搭建一个Minecraft服务器](/docs/CommunityShare/Geek/raspberry-guide)
-
-- [常用Katex语法](/docs/CommunityShare/Geek/Katex/index)
-
-## 心理健康
-
-- [程序员 Burnout 自救指南](/docs/CommunityShare/MentalHealth/burnout-guide) - 识别和应对职业倦怠
-
-## RAG
-
-- [RAG toy demo](/docs/CommunityShare/RAG/rag)
-
-## 身体健康
-
-- 久坐办公的解决方案
-- 程序员健身指南
-- 饮食与营养建议
-- 睡眠质量改善
+<CommunityShareIndex />


### PR DESCRIPTION
## 背景
\`app/docs/CommunityShare/index.mdx\` 一直是人工维护的 Markdown 列表，已经明显落后：

- 缺列 5 个实际存在的分类：\`Amazing-AI-Tools / Language / Leetcode / Life / Personal-Study-Notes\`
- 反向遗留"身体健康"分类（没对应目录，只有标题和 4 个空条目占位）
- 社区每新增一篇都得记得回来改 index，事实上没人这么做

这也是 #110 最早想解决的问题。LynPtl 在 #110 里方向是对的，但实现路线：
1. 引入 \`glob\` + \`gray-matter\` 两个新依赖
2. 写一个 Node 脚本 \`scripts/generate-community-index.js\` 走一遍目录 + 解析 frontmatter
3. 把生成结果写回静态 \`index.mdx\`
4. 接 CI workflow 让它定期跑

这条路线的问题：fumadocs 本身已经在跑目录扫描 + slug 规范化（包括 \`lib/source.ts\` 里给 \`CommunityShare/Leetcode\` 做的**拼音 slug transform**——硬拼 URL 会漏掉这个 transform），再自己复一份属于重复造轮子；而且 \`index.mdx\` 留在 git 里"被脚本重写"的文件，prettier / docId sync 等其他 workflow 容易互相打架。#110 里 TSK 也留了 "需要加依赖、workflow 要接" 的 Changes Requested，7 个月没跟进。

## 方案（这个 PR）
改成 **server component 实时从 fumadocs source 读取**，零新增依赖、零脚本、零 CI 步骤：

\`app/components/CommunityShareIndex.tsx\`:
- \`source.getPages()\` 拉所有页面，filter path 以 \`CommunityShare/\` 开头
- 按第一级子目录分组 → 每组一个分类 section
- 分类标题：优先读子目录 \`index.mdx\` 的 frontmatter.title，没 index 时降级用目录名
- 翻译版（\`lang === \"en\"\` 或文件名以 \`.en\` 结尾）统一过滤，列表只出原文 URL；语言切换仍由 \`[...slug]/page.tsx\` 的 cookie 逻辑负责
- 条目数超过阈值 (12) 的分类折叠成"查看全部 N 篇 →"单行链接，避免 Leetcode（49 篇）把首页顶爆
- 所有链接走 \`page.url\`，不硬拼 \`/docs/CommunityShare/<dir>\`（Leetcode 的拼音 slug transform 靠这个保留）

\`app/docs/CommunityShare/index.mdx\`:
- 保留 intro 段落 / 投稿引导 / 版权说明
- 移除全部硬编码分类列表，换成 \`<CommunityShareIndex />\`

## 本地验证
\`\`\`
$ curl -s localhost:3010/docs/CommunityShare | grep -oE \"[0-9]+ 篇\" | sort -u
1 篇  （Amazing-AI-Tools, Language, Life, Personal-Study-Notes — 新挖出来的空/单篇分类）
3 篇  （MentalHealth, RAG）
11 篇 （Geek — 技术分享）
49 篇 （Leetcode — 折叠为"查看全部 49 篇 →"）
\`\`\`
\"身体健康"分类消失；新分类自动出现。

## 关联 / 关闭
- 取代 #110，关掉那个 PR（credits 保留，LynPtl 最早指出了手维护会过期这个根本问题）
- 不引入 \`glob\` / \`gray-matter\`，不加 workflow 步骤
- \`lib/source.ts\` 里 Leetcode 的拼音 slug transform 被这个组件复用，不再需要在索引脚本里重复一遍

## Test plan
- [x] 本地 dev server (\`localhost:3010/docs/CommunityShare\`) 验证所有 8 个分类正确渲染，Leetcode 触发折叠
- [x] \`pnpm tsc --noEmit\` 对改动文件无报错
- [ ] 合并部署后目视 Prod 页面
- [ ] 随便往 CommunityShare/XXX 放一篇新文章，确认不需要改 index.mdx 就能出现在索引里（下次社区贡献时自然验证）