### PR TITLE
fix(assistant): 切换免费模型 Intern-S1 → GLM-4.6V-Flash + 加关闭按钮 (#285)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,8 +24,11 @@ INDEXNOW_API_TOKEN=
 #Open的Key
 INDEXNOW_KEY=5b6ef14a7406496b8a2ce8ab17820b34
 NEXT_PUBLIC_SITE_URL=https://involutionhell.com
-# 内部识别/认证 Key
+# 书生 Intern-S1 Key（已弃用：默认免费模型已切换至 GLM-4.6V-Flash）
 INTERN_KEY=
+# 智谱 AI 开放平台 API Key，聊天与建议接口的默认免费模型 GLM-4.6V-Flash
+# 在 https://open.bigmodel.cn/ 注册后获取
+ZHIPU_API_KEY=
 # Neon 项目 ID
 NEON_PROJECT_ID=
 # Neon 提供的 Postgres 连接。

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -33,9 +33,16 @@ export async function POST(req: Request) {
   const proxyReq = req.clone();
 
   // ====== 尝试优雅降级代理到 Java 后端 ======
+  // Java 后端 /openai/responses/stream 带 @SaCheckLogin，匿名请求必 401；
+  // 直接跳过代理省掉 5s 超时，也避免 401 文案被上游误显示为"unauthorized"。
+  const hasAuthToken = Boolean(req.headers.get("x-satoken"));
   try {
+    if (!hasAuthToken) {
+      throw new Error("Anonymous request, skip backend proxy.");
+    }
     const backendUrl = process.env.BACKEND_URL;
     if (!backendUrl) throw new Error("BACKEND_URL is not configured.");
+
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000); // 5秒超时
 

--- a/app/components/assistant-ui/SettingsDialog.tsx
+++ b/app/components/assistant-ui/SettingsDialog.tsx
@@ -58,7 +58,7 @@ export const SettingsDialog = ({
             >
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="intern" id="intern" />
-                <Label htmlFor="intern">InternS1 (Free)</Label>
+                <Label htmlFor="intern">GLM-4.6V-Flash (Free)</Label>
               </div>
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="openai" id="openai" />
@@ -176,11 +176,15 @@ export const SettingsDialog = ({
           )}
 
           {provider === "intern" && (
-            <div className="space-y-2">
-              <div className="text-sm text-muted-foreground">
-                感谢上海AILab的书生大模型对本项目的算力支持，Intern-AI
-                模型已预配置，无需提供 API Key。
-              </div>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                当前免费模型为智谱 GLM-4.6V-Flash（128K
+                上下文，支持多模态），由站点统一承担费用，无需提供 API Key。
+              </p>
+              <p className="text-xs">
+                🙏 特别鸣谢上海 AI Lab 书生 Intern-S1
+                为本项目提供首发算力支持——第一个金主，永远铭记。
+              </p>
             </div>
           )}
         </div>

--- a/app/components/assistant-ui/assistant-modal.tsx
+++ b/app/components/assistant-ui/assistant-modal.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { BotIcon, ChevronDownIcon } from "lucide-react";
+import { BotIcon, ChevronDownIcon, XIcon } from "lucide-react";
 
-import { type FC, forwardRef, useState, useEffect } from "react";
+import { type FC, forwardRef, useState, useEffect, useCallback } from "react";
 import { AssistantModalPrimitive } from "@assistant-ui/react";
 
 import { Thread } from "@/app/components/assistant-ui/thread";
@@ -30,6 +30,13 @@ export const AssistantModal: FC<AssistantModalProps> = ({
   isLoadingWelcome,
 }) => {
   const [showBubble, setShowBubble] = useState(false);
+  // 受控状态：允许模态框内部的 X 按钮主动关闭窗口
+  // issue #285: 原先只能靠 Trigger/点击外部/Esc 关闭，用户反馈不知道怎么关窗
+  const [open, setOpen] = useState(false);
+
+  const handleCloseModal = useCallback(() => {
+    setOpen(false);
+  }, []);
 
   useEffect(() => {
     // 检查本次访问是否已关闭过气泡
@@ -61,7 +68,7 @@ export const AssistantModal: FC<AssistantModalProps> = ({
   };
 
   return (
-    <AssistantModalPrimitive.Root>
+    <AssistantModalPrimitive.Root open={open} onOpenChange={setOpen}>
       <AssistantModalPrimitive.Anchor className="aui-root aui-modal-anchor fixed right-4 bottom-4 size-14">
         {/* 自定义气泡组件 */}
         {showBubble && (
@@ -88,8 +95,18 @@ export const AssistantModal: FC<AssistantModalProps> = ({
       </AssistantModalPrimitive.Anchor>
       <AssistantModalPrimitive.Content
         sideOffset={16}
-        className="aui-root aui-modal-content z-50 h-[500px] w-[400px] overflow-clip rounded-xl border bg-popover p-0 text-popover-foreground shadow-md outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-1/2 data-[state=closed]:slide-out-to-right-1/2 data-[state=closed]:zoom-out data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-1/2 data-[state=open]:slide-in-from-right-1/2 data-[state=open]:zoom-in [&>.aui-thread-root]:bg-inherit"
+        className="aui-root aui-modal-content relative z-50 h-[500px] w-[400px] overflow-clip rounded-xl border bg-popover p-0 text-popover-foreground shadow-md outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-1/2 data-[state=closed]:slide-out-to-right-1/2 data-[state=closed]:zoom-out data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-1/2 data-[state=open]:slide-in-from-right-1/2 data-[state=open]:zoom-in [&>.aui-thread-root]:bg-inherit"
       >
+        {/* 右上角关闭按钮，issue #285：用户找不到关闭模态框的显式入口 */}
+        <button
+          type="button"
+          onClick={handleCloseModal}
+          aria-label="Close assistant"
+          className="aui-modal-close absolute top-2 right-2 z-10 inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <XIcon className="size-4" />
+          <span className="sr-only">Close assistant</span>
+        </button>
         <Thread
           errorMessage={errorMessage}
           showSettingsAction={showSettingsAction}

--- a/lib/ai/providers/intern.ts
+++ b/lib/ai/providers/intern.ts
@@ -1,22 +1,33 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
 /**
- * Create Intern-AI model instance
- * Uses environment variable INTERN_KEY for API key
- * 在开发环境下，临时映射到 Deepseek 进行测试
- * @returns Configured Intern-AI model instance
+ * 免费聊天模型：智谱 GLM-4.6V-Flash
+ *
+ * 历史原因：此前默认走上海 AI Lab 的书生 Intern-S1，现因 key 过期改接智谱
+ * GLM-4.6V-Flash（同样免费、128K 上下文、支持多模态）。为避免破坏用户
+ * localStorage 里已有的 provider="intern" 设置，函数/Provider 名保留 `intern`
+ * 作为语义上的"免费兜底模型"标识。
+ *
+ * 开发环境仍可通过 DEEPSEEK_API_KEY 快速切换到 Deepseek 接口做调试。
+ * 生产环境需要在服务端配置 ZHIPU_API_KEY（智谱 AI 开放平台）。
  */
 export function createInternModel() {
   const isDev = process.env.NODE_ENV === "development";
 
-  const intern = createOpenAICompatible({
-    name: "intern",
-    baseURL: isDev
-      ? "https://api.deepseek.com" // 开发环境临时使用 Deepseek 接口测试
-      : "https://chat.intern-ai.org.cn/api/v1/",
-    apiKey: isDev ? process.env.DEEPSEEK_API_KEY : process.env.INTERN_KEY,
+  if (isDev && process.env.DEEPSEEK_API_KEY) {
+    const deepseek = createOpenAICompatible({
+      name: "deepseek",
+      baseURL: "https://api.deepseek.com",
+      apiKey: process.env.DEEPSEEK_API_KEY,
+    });
+    return deepseek("deepseek-chat");
+  }
+
+  const glm = createOpenAICompatible({
+    name: "zhipu",
+    baseURL: "https://open.bigmodel.cn/api/paas/v4/",
+    apiKey: process.env.ZHIPU_API_KEY,
   });
 
-  // Use the specific model configured for this project
-  return intern(isDev ? "deepseek-chat" : "intern-s1");
+  return glm("glm-4.6v-flash");
 }


### PR DESCRIPTION
## Closes
#285

## 问题
1. 在归档分类（Classified Archives）页点投稿，聊天机器人发消息直接报 `unauthorized`，建议问题点击也无响应。
2. 聊天窗口没有显式关闭/最小化按钮，边框一直悬浮遮挡页面内容。

## 根因
1. 默认免费模型 Intern-S1 的 `INTERN_KEY` 已过期 → 本地兜底推理也 401 → 错误文案透传到 UI。
2. 模态框当前只能靠 Trigger 按钮（变成 ChevronDown 形态）/点击外部/Esc 关闭，用户发现不了。
3. Java 后端 `/openai/responses/stream` 带 `@SaCheckLogin`，匿名用户必 401，但 Next.js 代理仍会尝试再超时 5 秒，造成噪音。

## 改动
- **切换免费模型**：`lib/ai/providers/intern.ts` 底层改接智谱 GLM-4.6V-Flash（128K 上下文、多模态、免费），走 OpenAI-compatible 接口，用 `ZHIPU_API_KEY`。provider 名保留 `intern` 避免 localStorage 迁移。
- **匿名跳过后端代理**：`/api/chat/route.ts` 发现没有 `x-satoken` 时直接短路到本地 GLM 推理，省 5s 超时，避免后端 401 文案干扰。
- **模态框关闭按钮**：`assistant-modal.tsx` 改用受控 `open` 状态，右上角新增 X 按钮，点击关闭窗口。
- **文案与致谢**：SettingsDialog 更新为 "GLM-4.6V-Flash (Free)"，保留对上海 AI Lab 书生 Intern-S1 首发算力赞助的致谢。
- **环境变量**：`.env.sample` 新增 `ZHIPU_API_KEY` 占位。

## ⚠️ 部署须知
**Vercel 环境变量必须新增 `ZHIPU_API_KEY`**（从 https://open.bigmodel.cn/ 获取），否则线上还是会 401。`INTERN_KEY` 可以保留但实际不再使用。

## 测试
- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 无新增 error（既存 warnings 不动）
- [ ] 本地 dev 验证：登出状态发消息 → GLM 正常回流
- [ ] 本地 dev 验证：右上 X 按钮点击后窗口关闭
- [ ] 生产部署后验证匿名用户聊天可用

## 后续可做（基于 GLM-4.6V-Flash 能力，单独 PR）
- **图片输入**：读者粘贴/拖拽截图问文档里的图或公式
- **思考模式 toggle**：深度推理开关（`thinking: { type: "enabled" }`）
- **更长上下文**：利用 128K 窗口把相关章节一起喂入