### PR TITLE
fix(assistant): 回应 #293 CR — 匿名短路不抛错 + ZHIPU_API_KEY 显式校验

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -35,60 +35,65 @@ export async function POST(req: Request) {
   // ====== 尝试优雅降级代理到 Java 后端 ======
   // Java 后端 /openai/responses/stream 带 @SaCheckLogin，匿名请求必 401；
   // 直接跳过代理省掉 5s 超时，也避免 401 文案被上游误显示为"unauthorized"。
-  const hasAuthToken = Boolean(req.headers.get("x-satoken"));
-  try {
-    if (!hasAuthToken) {
-      throw new Error("Anonymous request, skip backend proxy.");
-    }
-    const backendUrl = process.env.BACKEND_URL;
-    if (!backendUrl) throw new Error("BACKEND_URL is not configured.");
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5秒超时
-
-    // 原封不动把前端的参数丢给 Java
-    let proxyRes: Response;
-    try {
-      proxyRes = await fetch(`${backendUrl}/openai/responses/stream`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          // 浏览器侧用 x-satoken 传递 token，转发给后端时改回后端期望的 satoken
-          ...(req.headers.get("x-satoken")
-            ? { satoken: req.headers.get("x-satoken")! }
-            : {}),
-        },
-        body: await proxyReq.text(),
-        signal: controller.signal,
-      });
-    } finally {
-      // 无论成功还是抛出（网络错误/超时中断），都清除定时器
-      clearTimeout(timeoutId);
-    }
-
-    // 如果 Java 后端返回成功，则直接把它的流传回浏览器，提前结束
-    if (proxyRes.ok && proxyRes.body) {
-      console.log(
-        "[Chat Fallback Proxy] 🚀 Java Backend responded successfully. Piping stream...",
-      );
-      return new Response(proxyRes.body, {
-        headers: {
-          "Content-Type":
-            proxyRes.headers.get("Content-Type") || "text/plain; charset=utf-8",
-        },
-      });
-    } else {
-      console.warn(
-        `[Chat Fallback Proxy] ⚠️ Java Backend returned status: ${proxyRes.status}, fallback to local Next.js inference.`,
-      );
-    }
-  } catch (error) {
-    console.warn(
-      `[Chat Fallback Proxy] ❌ Java Backend unavailable or timed out, fallback to local Next.js inference. Error:`,
-      error,
+  // 匿名分支走显式 if 短路，不进 try/catch —— 否则每个匿名请求都会被 catch
+  // 打成 "Java Backend unavailable" 带 stack 的 warn，生产日志会刷爆
+  // （Copilot CR #1）。
+  const satoken = req.headers.get("x-satoken");
+  if (!satoken) {
+    console.log(
+      "[Chat Fallback Proxy] ⏭️  Anonymous request, skip backend proxy, use local inference.",
     );
+  } else {
+    try {
+      const backendUrl = process.env.BACKEND_URL;
+      if (!backendUrl) throw new Error("BACKEND_URL is not configured.");
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000); // 5秒超时
+
+      // 原封不动把前端的参数丢给 Java
+      let proxyRes: Response;
+      try {
+        proxyRes = await fetch(`${backendUrl}/openai/responses/stream`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            // 浏览器侧用 x-satoken 传递 token，转发给后端时改回后端期望的 satoken
+            satoken,
+          },
+          body: await proxyReq.text(),
+          signal: controller.signal,
+        });
+      } finally {
+        // 无论成功还是抛出（网络错误/超时中断），都清除定时器
+        clearTimeout(timeoutId);
+      }
+
+      // 如果 Java 后端返回成功，则直接把它的流传回浏览器，提前结束
+      if (proxyRes.ok && proxyRes.body) {
+        console.log(
+          "[Chat Fallback Proxy] 🚀 Java Backend responded successfully. Piping stream...",
+        );
+        return new Response(proxyRes.body, {
+          headers: {
+            "Content-Type":
+              proxyRes.headers.get("Content-Type") ||
+              "text/plain; charset=utf-8",
+          },
+        });
+      } else {
+        console.warn(
+          `[Chat Fallback Proxy] ⚠️ Java Backend returned status: ${proxyRes.status}, fallback to local Next.js inference.`,
+        );
+      }
+    } catch (error) {
+      console.warn(
+        `[Chat Fallback Proxy] ❌ Java Backend unavailable or timed out, fallback to local Next.js inference. Error:`,
+        error,
+      );
+    }
   }
-  // ====== 代理失败，继续往下走，启用备选方案（本地直连 AI）======
+  // ====== 代理失败/匿名短路，继续往下走，启用备选方案（本地直连 AI）======
 
   try {
     // 先把 body 消费掉，再并行验证用户身份

--- a/lib/ai/providers/intern.ts
+++ b/lib/ai/providers/intern.ts
@@ -23,10 +23,22 @@ export function createInternModel() {
     return deepseek("deepseek-chat");
   }
 
+  // 显式校验 ZHIPU_API_KEY：若漏配，下游 401 又会在 UI 上变成 "unauthorized"
+  // 透传 —— 正好绕回 issue #285 原本要修的症状。在这里早抛出带指引的错误，
+  // 运维看日志一眼知道补哪个 env var，避免二次塌房（Copilot CR #2）。
+  const zhipuApiKey = process.env.ZHIPU_API_KEY;
+  if (!zhipuApiKey || zhipuApiKey.trim() === "") {
+    throw new Error(
+      "Missing required environment variable ZHIPU_API_KEY. " +
+        "配置位置：Vercel Project Settings → Environment Variables。" +
+        "免费 key 从 https://open.bigmodel.cn/ 获取。",
+    );
+  }
+
   const glm = createOpenAICompatible({
     name: "zhipu",
     baseURL: "https://open.bigmodel.cn/api/paas/v4/",
-    apiKey: process.env.ZHIPU_API_KEY,
+    apiKey: zhipuApiKey,
   });
 
   return glm("glm-4.6v-flash");


### PR DESCRIPTION
## 背景
#293 已合入，Copilot 在 review 中留了 2 条意见，本 PR 全部回应。

## 改动

### 1. `app/api/chat/route.ts`（Copilot CR #1）
**问题**：上一版用 \`throw new Error(\"Anonymous request, skip backend proxy.\")\` 触发 fallback，副作用是**每个匿名请求**都会被外层 catch 打成 \`Java Backend unavailable or timed out, fallback to local Next.js inference. Error: ...\` 带 stack 的 warn，生产日志被刷爆。

**修复**：改成显式 \`if-else\` 分支，匿名请求不进 try/catch，只打一行 info 级日志：
\`\`\`
[Chat Fallback Proxy] ⏭️  Anonymous request, skip backend proxy, use local inference.
\`\`\`
顺带把重复读 header 的三元展开 \`...(req.headers.get(\"x-satoken\") ? { satoken: ... } : {})\` 简化为 \`satoken\` 缩写（都已确认非空才进此分支）。

### 2. `lib/ai/providers/intern.ts`（Copilot CR #2）
**问题**：上一版把 \`process.env.ZHIPU_API_KEY\` 直接喂给 \`createOpenAICompatible\`。若 Vercel 漏配该环境变量 → 下游 401/500 → UI 上依旧表现为 \"unauthorized\" —— **这正是 issue #285 的原症状**，相当于绕一圈还是炸。

**修复**：在创建 client 前显式校验，缺失时抛出带 **Vercel 配置指引** 的错误，运维看日志一眼就知道补哪个 var：
\`\`\`
Missing required environment variable ZHIPU_API_KEY. 配置位置：Vercel
Project Settings → Environment Variables。免费 key 从 https://open.bigmodel.cn/ 获取。
\`\`\`

## 测试
- [x] \`pnpm typecheck\` 通过
- [ ] 本地验证匿名请求日志：只有一行 \`⏭️  Anonymous request\`，没有 warn 噪音
- [ ] 故意清空 ZHIPU_API_KEY 后验证：错误消息包含 Vercel 指引