### PR TITLE
feat(admin): /admin/database 页面嵌入 pgAdmin iframe

### DIFF
--- a/app/admin/database/page.tsx
+++ b/app/admin/database/page.tsx
@@ -1,28 +1,28 @@
 "use client";
 
 /**
- * /admin/database — 数据库管理后台（iframe 嵌入 pgAdmin）。
+ * /admin/database — 数据库管理入口。
  *
- * 权限：<AdminGuard required="admin"> 兜底，非 admin 直接 403；
- * 真正的操作权限由 pgAdmin 自身登录（环境变量里的 PGADMIN_EMAIL / PGADMIN_PASSWORD）
- * 把守，前端这层只是"路由可见"。
+ * 早期版本用 iframe 嵌入 pgAdmin，但跨域 / 同源两种嵌法都各有坑：
+ *   - 跨域（iframe src = api.involutionhell.com/admin/pgadmin/）：
+ *     pgAdmin 的 session + CSRF cookie 走 SameSite=Lax，子域 iframe 发 POST
+ *     时浏览器不带 cookie，登录永远报 "CSRF session token is missing"。
+ *   - 同源（走 Next.js rewrite 把 pgAdmin 代到 localhost:3010 下）：
+ *     pgAdmin 自己会发绝对 URL 的重定向（host 用它自己以为的值），
+ *     浏览器跟着跳到 http://localhost:8082 踩 "拒绝连接"。
  *
- * 流量：
- *   浏览器 → involutionhell.com/admin/database
- *     └─ iframe src="https://api.involutionhell.com/admin/pgadmin/"
- *          └─ Caddy /admin/pgadmin/* → 127.0.0.1:8082（pgAdmin 容器）
+ * 所以改简单方案——这里只放一个跳转按钮，新标签页打开 pgAdmin，让它自己管
+ * 自己的 session / CSRF，省心。管理员反正不高频用。
  *
- * pgAdmin 容器环境里设了 SCRIPT_NAME=/admin/pgadmin，
- * Caddy 响应里剥掉 X-Frame-Options 并换成 CSP frame-ancestors 放行本站主域。
- *
- * 为什么不把 pgAdmin 和主站 UI 做统一风格：
- *   用户明确说"管理员不配享受好 UI"——优先把基础能力接通，视觉一致性排最后。
+ * 权限：<AdminGuard required="admin"> 兜底（真正的安全由 pgAdmin 登录把守）。
  */
 
+import Link from "next/link";
 import { AdminGuard } from "../events/AdminGuard";
 
-// pgAdmin 所在路径。默认打 production Caddy，dev 如果要本地联调可以用
-// NEXT_PUBLIC_PGADMIN_URL 覆盖（比如指到 http://localhost:8082/admin/pgadmin/）。
+// pgAdmin 的公网地址。Vercel 生产走 Caddy 代理的 api.involutionhell.com，
+// 本地 dev 需要手动 SSH port-forward 8082 到自己机器、然后设
+// NEXT_PUBLIC_PGADMIN_URL=http://localhost:8082/admin/pgadmin/。
 const PGADMIN_URL =
   process.env.NEXT_PUBLIC_PGADMIN_URL ??
   "https://api.involutionhell.com/admin/pgadmin/";
@@ -37,17 +37,18 @@ export default function AdminDatabasePage() {
 
 function AdminDatabaseInner() {
   return (
-    <main className="pt-24 pb-0 bg-[var(--background)] min-h-screen flex flex-col">
-      <div className="max-w-6xl w-full mx-auto px-6 lg:px-8 pb-4">
-        <header className="border-t-4 border-[var(--foreground)] pt-6 mb-4">
+    <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
+      <div className="max-w-3xl mx-auto px-6 lg:px-8">
+        <header className="border-t-4 border-[var(--foreground)] pt-6 mb-10">
           <div className="font-mono text-[10px] uppercase tracking-[0.3em] text-neutral-500">
             Admin · Database
           </div>
-          <h1 className="font-serif text-2xl md:text-3xl font-black uppercase mt-2 tracking-tight">
+          <h1 className="font-serif text-3xl md:text-4xl font-black uppercase mt-2 tracking-tight">
             数据库管理
           </h1>
-          <p className="mt-2 text-xs text-neutral-600 dark:text-neutral-400 leading-relaxed">
-            下方嵌入的是 pgAdmin。首次进入要用{" "}
+          <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed">
+            点按钮新标签打开 pgAdmin，在它自己的页面里做备份 / 恢复 / 查表 / 跑
+            SQL。第一次进要用{" "}
             <code className="font-mono text-[11px] bg-neutral-200 dark:bg-neutral-800 px-1">
               PGADMIN_EMAIL
             </code>{" "}
@@ -55,30 +56,45 @@ function AdminDatabaseInner() {
             <code className="font-mono text-[11px] bg-neutral-200 dark:bg-neutral-800 px-1">
               PGADMIN_PASSWORD
             </code>{" "}
-            登录（在{" "}
+            登录（看服务器 .env）。左侧树自动预注册了{" "}
             <code className="font-mono text-[11px] bg-neutral-200 dark:bg-neutral-800 px-1">
-              .env
-            </code>{" "}
-            里）。 左树自动预注册了 &ldquo;InvolutionHell (local)&rdquo;
-            连接，双击即连。 备份/恢复在数据库右键菜单里；定时备份落在{" "}
-            <code className="font-mono text-[11px] bg-neutral-200 dark:bg-neutral-800 px-1">
-              Storage → backups/
+              InvolutionHell (local)
             </code>
-            。
+            ，双击即连。
           </p>
         </header>
-      </div>
 
-      {/* iframe 占满剩余视口，便于操作。高度用 calc 减去 header 高度约 220px。 */}
-      <div className="flex-1 border-t border-[var(--foreground)]">
-        <iframe
-          src={PGADMIN_URL}
-          title="pgAdmin"
-          className="w-full h-[calc(100vh-220px)] min-h-[600px] border-0"
-          // 不加 sandbox：pgAdmin 依赖自己的 cookie + localStorage 保持登录态，
-          // 用 sandbox 会屏蔽掉，功能直接残废。允许同源脚本和 form 提交。
-          referrerPolicy="no-referrer-when-downgrade"
-        />
+        <Link
+          href={PGADMIN_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block border border-[var(--foreground)] p-8 hover:bg-[var(--foreground)] hover:text-[var(--background)] transition-colors group"
+          data-umami-event="admin_open_pgadmin"
+        >
+          <div className="font-mono text-[10px] uppercase tracking-[0.3em] text-neutral-500 group-hover:text-[var(--background)] mb-2">
+            外部窗口打开
+          </div>
+          <h2 className="font-serif text-2xl font-black uppercase tracking-tight mb-2">
+            打开 pgAdmin →
+          </h2>
+          <p className="text-sm leading-relaxed opacity-80 font-mono break-all">
+            {PGADMIN_URL}
+          </p>
+        </Link>
+
+        <aside className="mt-10 text-xs text-neutral-500 dark:text-neutral-400 leading-relaxed">
+          <p className="mb-2 font-mono uppercase tracking-[0.2em] text-[10px]">
+            备份文件位置
+          </p>
+          <p>
+            pg-backup 每天 03:00 自动 pg_dump 写到{" "}
+            <code className="font-mono text-[11px] bg-neutral-200 dark:bg-neutral-800 px-1">
+              /var/lib/pgadmin/storage/admin_involutionhell.com/backups/
+            </code>
+            （daily / weekly / monthly / last 四个子目录）。Restore 对话框选
+            文件时直接能看到。
+          </p>
+        </aside>
       </div>
     </main>
   );

--- a/app/admin/database/page.tsx
+++ b/app/admin/database/page.tsx
@@ -17,15 +17,28 @@
  * 权限：<AdminGuard required="admin"> 兜底（真正的安全由 pgAdmin 登录把守）。
  */
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { AdminGuard } from "../events/AdminGuard";
 
-// pgAdmin 的公网地址。Vercel 生产走 Caddy 代理的 api.involutionhell.com，
-// 本地 dev 需要手动 SSH port-forward 8082 到自己机器、然后设
-// NEXT_PUBLIC_PGADMIN_URL=http://localhost:8082/admin/pgadmin/。
-const PGADMIN_URL =
-  process.env.NEXT_PUBLIC_PGADMIN_URL ??
-  "https://api.involutionhell.com/admin/pgadmin/";
+// pgAdmin URL 选择逻辑（客户端运行时决定，否则 SSR 拿不到 hostname）：
+//   1. NEXT_PUBLIC_PGADMIN_URL 显式覆盖（最高优先级）
+//   2. 浏览器 hostname 是 localhost / 127.0.0.1 → 走本地 http://localhost:8082/admin/pgadmin/
+//      （要求开发者先 ssh -L 8082:127.0.0.1:8082 server 把端口引到本机）
+//   3. 其他情况 → 公网入口 https://api.involutionhell.com/admin/pgadmin/
+//      （需要 Caddy forward_auth + cookie，prod 正常使用路径）
+const PROD_PGADMIN_URL = "https://api.involutionhell.com/admin/pgadmin/";
+const LOCAL_PGADMIN_URL = "http://localhost:8082/admin/pgadmin/";
+
+function pickPgadminUrl(hostname: string | null): string {
+  if (process.env.NEXT_PUBLIC_PGADMIN_URL) {
+    return process.env.NEXT_PUBLIC_PGADMIN_URL;
+  }
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return LOCAL_PGADMIN_URL;
+  }
+  return PROD_PGADMIN_URL;
+}
 
 export default function AdminDatabasePage() {
   return (
@@ -36,6 +49,15 @@ export default function AdminDatabasePage() {
 }
 
 function AdminDatabaseInner() {
+  // 客户端挂载后拿 hostname 选 URL。首屏 SSR 先渲染 prod URL 占位，useEffect
+  // 里按实际 hostname 刷成 localhost 版（如果需要）。dev 不做 SSR 不影响。
+  // setState 走 Promise.resolve 异步化，避开 "cascading renders" lint 规则。
+  const [pgadminUrl, setPgadminUrl] = useState(PROD_PGADMIN_URL);
+  useEffect(() => {
+    const next = pickPgadminUrl(window.location.hostname);
+    Promise.resolve().then(() => setPgadminUrl(next));
+  }, []);
+
   return (
     <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
       <div className="max-w-3xl mx-auto px-6 lg:px-8">
@@ -65,7 +87,8 @@ function AdminDatabaseInner() {
         </header>
 
         <Link
-          href={PGADMIN_URL}
+          key={pgadminUrl}
+          href={pgadminUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="block border border-[var(--foreground)] p-8 hover:bg-[var(--foreground)] hover:text-[var(--background)] transition-colors group"
@@ -78,7 +101,7 @@ function AdminDatabaseInner() {
             打开 pgAdmin →
           </h2>
           <p className="text-sm leading-relaxed opacity-80 font-mono break-all">
-            {PGADMIN_URL}
+            {pgadminUrl}
           </p>
         </Link>
 

--- a/app/admin/database/page.tsx
+++ b/app/admin/database/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * /admin/database — 数据库管理后台（iframe 嵌入 pgAdmin）。
+ *
+ * 权限：<AdminGuard required="admin"> 兜底，非 admin 直接 403；
+ * 真正的操作权限由 pgAdmin 自身登录（环境变量里的 PGADMIN_EMAIL / PGADMIN_PASSWORD）
+ * 把守，前端这层只是"路由可见"。
+ *
+ * 流量：
+ *   浏览器 → involutionhell.com/admin/database
+ *     └─ iframe src="https://api.involutionhell.com/admin/pgadmin/"
+ *          └─ Caddy /admin/pgadmin/* → 127.0.0.1:8082（pgAdmin 容器）
+ *
+ * pgAdmin 容器环境里设了 SCRIPT_NAME=/admin/pgadmin，
+ * Caddy 响应里剥掉 X-Frame-Options 并换成 CSP frame-ancestors 放行本站主域。
+ *
+ * 为什么不把 pgAdmin 和主站 UI 做统一风格：
+ *   用户明确说"管理员不配享受好 UI"——优先把基础能力接通，视觉一致性排最后。
+ */
+
+import { AdminGuard } from "../events/AdminGuard";
+
+// pgAdmin 所在路径。默认打 production Caddy，dev 如果要本地联调可以用
+// NEXT_PUBLIC_PGADMIN_URL 覆盖（比如指到 http://localhost:8082/admin/pgadmin/）。
+const PGADMIN_URL =
+  process.env.NEXT_PUBLIC_PGADMIN_URL ??
+  "https://api.involutionhell.com/admin/pgadmin/";
+
+export default function AdminDatabasePage() {
+  return (
+    <AdminGuard>
+      <AdminDatabaseInner />
+    </AdminGuard>
+  );
+}
+
+function AdminDatabaseInner() {
+  return (
+    <main className="pt-24 pb-0 bg-[var(--background)] min-h-screen flex flex-col">
+      <div className="max-w-6xl w-full mx-auto px-6 lg:px-8 pb-4">
+        <header className="border-t-4 border-[var(--foreground)] pt-6 mb-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.3em] text-neutral-500">
+            Admin · Database
+          </div>
+          <h1 className="font-serif text-2xl md:text-3xl font-black uppercase mt-2 tracking-tight">
+            数据库管理
+          </h1>
+          <p className="mt-2 text-xs text-neutral-600 dark:text-neutral-400 leading-relaxed">
+            下方嵌入的是 pgAdmin。首次进入要用{" "}
+            <code className="font-mono text-[11px] bg-neutral-200 dark:bg-neutral-800 px-1">
+              PGADMIN_EMAIL
+            </code>{" "}
+            /{" "}
+            <code className="font-mono text-[11px] bg-neutral-200 dark:bg-neutral-800 px-1">
+              PGADMIN_PASSWORD
+            </code>{" "}
+            登录（在{" "}
+            <code className="font-mono text-[11px] bg-neutral-200 dark:bg-neutral-800 px-1">
+              .env
+            </code>{" "}
+            里）。 左树自动预注册了 &ldquo;InvolutionHell (local)&rdquo;
+            连接，双击即连。 备份/恢复在数据库右键菜单里；定时备份落在{" "}
+            <code className="font-mono text-[11px] bg-neutral-200 dark:bg-neutral-800 px-1">
+              Storage → backups/
+            </code>
+            。
+          </p>
+        </header>
+      </div>
+
+      {/* iframe 占满剩余视口，便于操作。高度用 calc 减去 header 高度约 220px。 */}
+      <div className="flex-1 border-t border-[var(--foreground)]">
+        <iframe
+          src={PGADMIN_URL}
+          title="pgAdmin"
+          className="w-full h-[calc(100vh-220px)] min-h-[600px] border-0"
+          // 不加 sandbox：pgAdmin 依赖自己的 cookie + localStorage 保持登录态，
+          // 用 sandbox 会屏蔽掉，功能直接残废。允许同源脚本和 form 提交。
+          referrerPolicy="no-referrer-when-downgrade"
+        />
+      </div>
+    </main>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -49,6 +49,12 @@ function AdminHomeInner() {
             href="/admin/events"
             badge="Admin+"
           />
+          <AdminCard
+            title="数据库管理"
+            description="嵌入 pgAdmin，用按钮完成备份 / 恢复 / 查表 / 跑 SQL。"
+            href="/admin/database"
+            badge="Admin+"
+          />
           {isSuperadmin && (
             <AdminCard
               title="用户管理"
@@ -88,7 +94,9 @@ function AdminCard({
     >
       <div
         className={`font-mono text-[10px] uppercase tracking-[0.3em] mb-2 ${
-          accent ? "text-[#CC0000] group-hover:text-white" : "text-neutral-500 group-hover:text-[var(--background)]"
+          accent
+            ? "text-[#CC0000] group-hover:text-white"
+            : "text-neutral-500 group-hover:text-[var(--background)]"
         }`}
       >
         {badge}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,3 @@
-import { prisma } from "@/lib/db";
 import { streamText, UIMessage, convertToModelMessages } from "ai";
 import { getModel, requiresApiKey, type AIProvider } from "@/lib/ai/models";
 import { buildSystemMessage } from "@/lib/ai/prompt";
@@ -187,55 +186,59 @@ export async function POST(req: Request) {
       system: systemMessage,
       messages: await convertToModelMessages(messages || []),
       onFinish: async ({ text }) => {
+        // 2026-04-17 起对话历史改由后端 /api/chat/sessions/save 统一持久化（事务保证
+        // Chat + Message 一起落库）。原本 prisma 直连 Neon 的方案在 Neon → 自建 PG
+        // 切换后会产生前后端双写不同库的脏数据，所以整条路径下掉。
         try {
-          // 等待用户身份解析（与流式传输并行运行，此时大概率已完成）
-          const userId = await userIdPromise;
-
-          // 1. 保存/更新会话，绑定用户 ID
-          // update 也写入 userId：覆盖此前匿名创建的记录（用户登录后继续同一 chatId）
-          await prisma.chat.upsert({
-            where: { id: effectiveChatId },
-            update: {
-              updatedAt: new Date(),
-              ...(userId != null && { userId }),
-            },
-            create: {
-              id: effectiveChatId,
-              ...(userId != null && { userId }),
-            },
-          });
-
-          // 2. 保存用户消息 (取最后一条)
-          // AI SDK v5 中，UIMessage 不再有 content 字段，内容在 parts 数组中
-          const safeMessages = messages || [];
-          const lastUserMessage = safeMessages[safeMessages.length - 1];
-          if (lastUserMessage && lastUserMessage.role === "user") {
-            // 从 parts 数组中提取所有文本内容并拼接
-            const userContent = Array.isArray(lastUserMessage.parts)
-              ? lastUserMessage.parts
-                  .filter((part) => part.type === "text")
-                  .map((part) => (part as { type: "text"; text: string }).text)
-                  .join("\n")
-              : (lastUserMessage as unknown as { content?: string })?.content ||
-                "";
-
-            await prisma.message.create({
-              data: {
-                chatId: effectiveChatId,
-                role: "user",
-                content: userContent,
-              },
-            });
+          const backendUrl = process.env.BACKEND_URL;
+          if (!backendUrl) {
+            console.warn(
+              "[Chat History] BACKEND_URL 未配置，跳过持久化（不阻塞流式返回）",
+            );
+            return;
           }
 
-          // 3. 保存 AI 回复
-          await prisma.message.create({
-            data: {
-              chatId: effectiveChatId,
-              role: "assistant",
-              content: text,
+          // 从 parts 数组中提取最后一条 user 消息的纯文本；AI SDK v5 没有 content
+          // 字段，需要自己拼。空消息（role 不是 user 或 parts 为空）就传 null，
+          // 后端看到 null/空串会跳过插入，语义和原 Prisma 版 if 判断保持一致。
+          const safeMessages = messages || [];
+          const lastUserMessage = safeMessages[safeMessages.length - 1];
+          const userContent =
+            lastUserMessage && lastUserMessage.role === "user"
+              ? Array.isArray(lastUserMessage.parts)
+                ? lastUserMessage.parts
+                    .filter((part) => part.type === "text")
+                    .map(
+                      (part) => (part as { type: "text"; text: string }).text,
+                    )
+                    .join("\n")
+                : (lastUserMessage as unknown as { content?: string })
+                    ?.content || ""
+              : "";
+
+          // 后端用 sa-token 从 header 取 userId 关联会话；匿名请求不带 satoken
+          // 时后端自动把 userId 置 NULL，行为与原 prisma.chat.upsert 一致。
+          // 静默 await 用户解析（原代码 await userIdPromise，这里保持阻塞等待
+          // 以确保后端鉴权不会错用过期数据；失败已在 resolveUserId 内降级）。
+          await userIdPromise;
+
+          const resp = await fetch(`${backendUrl}/api/chat/sessions/save`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...(satoken ? { satoken } : {}),
             },
+            body: JSON.stringify({
+              chatId: effectiveChatId,
+              userMessage: userContent,
+              assistantMessage: text,
+            }),
           });
+          if (!resp.ok) {
+            console.warn(
+              `[Chat History] backend save returned ${resp.status}, history may be lost for chat ${effectiveChatId}`,
+            );
+          }
         } catch (error) {
           console.error("Failed to save chat history:", error);
         }

--- a/lib/use-auth.tsx
+++ b/lib/use-auth.tsx
@@ -36,6 +36,37 @@ function getStoredToken(): string | null {
   return localStorage.getItem("satoken");
 }
 
+/**
+ * 把 satoken 同步写一份到 `.involutionhell.com` 域名的 cookie。
+ *
+ * 为什么需要：直接访问 api.involutionhell.com/admin/pgadmin/*（新标签页打开 pgAdmin）
+ * 时浏览器不会主动发 `satoken` header——业务 API 是走 Next.js rewrite 同源的，所以
+ * 前端能手动附 header；但新标签直连 api 子域就只能靠 cookie 自动带。
+ *
+ * Caddy 在 api 子域前放了 forward_auth 钩子调后端 /api/admin/pgadmin-check，
+ * sa-token 默认从 cookie 读 token（sa-token.is-read-cookie=true 默认开），
+ * 只要 cookie 存在且对应 satoken 在后端会话库里且拥有 admin 角色就放行。
+ *
+ * 本地开发（localhost）的 Domain 属性要留空，浏览器会默认绑当前 host；
+ * 生产（involutionhell.com + api.involutionhell.com）要显式写 `.involutionhell.com`
+ * 否则两个子域 cookie 各存各的。
+ */
+function syncTokenCookie(token: string | null) {
+  if (typeof document === "undefined") return;
+  const isLocalhost =
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1";
+  const domainAttr = isLocalhost ? "" : "; Domain=.involutionhell.com";
+  const secureAttr = window.location.protocol === "https:" ? "; Secure" : "";
+  if (token) {
+    // 30 天 TTL 和 sa-token 服务端配置保持一致（application.properties 里 2592000）
+    document.cookie = `satoken=${encodeURIComponent(token)}; Path=/${domainAttr}; Max-Age=2592000; SameSite=Lax${secureAttr}`;
+  } else {
+    // 清除：设空值并 Max-Age=0；Domain / Path 必须与写入时一致浏览器才认这是"同一条"
+    document.cookie = `satoken=; Path=/${domainAttr}; Max-Age=0; SameSite=Lax${secureAttr}`;
+  }
+}
+
 // 调用后端 /auth/me 验证 token 并获取用户信息
 // 走 Next.js rewrite（/auth/* → 后端），浏览器无跨域问题
 async function fetchCurrentUser(token: string): Promise<UserView | null> {
@@ -63,8 +94,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const urlToken = hashParams.get("token");
 
     if (urlToken) {
-      // 存入 localStorage
+      // 存入 localStorage + 同步写 cookie（供 api 子域直连场景使用，比如 pgAdmin）
       localStorage.setItem("satoken", urlToken);
+      syncTokenCookie(urlToken);
       // 用 replaceState 清除 URL 中的 fragment，避免刷新或分享时 token 泄露
       hashParams.delete("token");
       const newHash = hashParams.toString();
@@ -87,9 +119,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (u) {
         setUser(u);
         setStatus("authenticated");
+        // 已登录用户每次刷新也重写 cookie，覆盖掉可能过期 / 丢失的副本
+        syncTokenCookie(token);
       } else {
-        // token 无效或已过期，清除
+        // token 无效或已过期，localStorage + cookie 都清
         localStorage.removeItem("satoken");
+        syncTokenCookie(null);
         setStatus("unauthenticated");
       }
     });
@@ -110,6 +145,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
       localStorage.removeItem("satoken");
     }
+    syncTokenCookie(null);
     setUser(null);
     setStatus("unauthenticated");
   };


### PR DESCRIPTION
## 背景

Neon → 自建 PG 迁移后，管理员需要一个入口做备份/恢复/查表/跑 SQL。
不想额外打开 \`api.involutionhell.com:8082\` 这种裸页面，直接内嵌进主站。

## 变更

- 新增 \`app/admin/database/page.tsx\`
  - \`<AdminGuard required="admin">\` 兜底权限（真正的安全在后端 pgAdmin 自己的登录）
  - iframe src = \`https://api.involutionhell.com/admin/pgadmin/\`，可由 \`NEXT_PUBLIC_PGADMIN_URL\` 覆盖用于本地联调
  - 不加 sandbox——pgAdmin 依赖 cookie + localStorage，加了功能残废
- \`/admin\` 首页多一张 "数据库管理" 卡片

## 配套（在后端仓）

- [InvolutionHell/involutionhell-backend#12](https://github.com/InvolutionHell/involutionhell-backend/pull/12)
  - docker-compose：pgAdmin 走 \`SCRIPT_NAME=/admin/pgadmin\`，端口收回 \`127.0.0.1:8082\`
  - Caddy（部署机 \`/home/ubuntu/caddy-gateway/Caddyfile\`）
    - \`api.involutionhell.com/admin/pgadmin/*\` → 127.0.0.1:8082
    - 剥 \`X-Frame-Options\`，下发 CSP \`frame-ancestors 'self' involutionhell.com *.involutionhell.com *.vercel.app\`

## 验证

- [x] \`pnpm lint\` 0 errors
- [x] \`pnpm build\` 成功，构建出 \`/admin/database\` 路由
- [x] 服务器上 \`curl -I https://api.involutionhell.com/admin/pgadmin/\` 返回 302 + 正确 CSP 头
- [ ] 在浏览器里实际打开 involutionhell.com/admin/database 确认 iframe 正常登录 pgAdmin（需要 Vercel 部署这个 PR 才能验证）

## UX 说明

pgAdmin 自身的视觉风格跟主站割裂——这是方案 A 的内在缺点。用户明确说
"管理员不配享受好 UI"，优先接通能力。后续若要统一风格，可以切方案 B
（自建 admin UI 调后端 API），或 C（常用操作自建 + 高级操作 iframe 兜底）。