### PR TITLE
chore(docs): 清理 tag-one 占位符 → 真实内容标签（54 文件）

### DIFF
--- a/app/docs/CommunityShare/Geek/cloudflare-r2-sharex-free-image-hosting.en.mdx
+++ b/app/docs/CommunityShare/Geek/cloudflare-r2-sharex-free-image-hosting.en.mdx
@@ -3,7 +3,11 @@ title: Building a Personal/Team "Permanent" Image Host with Cloudflare R2 + Shar
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - image-hosting
+  - cloudflare-r2
+  - sharex
+  - self-hosting
+  - cdn
 docId: gj4bn01un0s0841berfvwrn5
 lang: en
 translatedFrom: zh

--- a/app/docs/CommunityShare/Geek/cloudflare-r2-sharex-free-image-hosting.mdx
+++ b/app/docs/CommunityShare/Geek/cloudflare-r2-sharex-free-image-hosting.mdx
@@ -3,7 +3,11 @@ title: 使用 Cloudflare R2 + ShareX 搭建个人/团队专属“永久”图床
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - image-hosting
+  - cloudflare-r2
+  - sharex
+  - self-hosting
+  - cdn
 docId: gj4bn01un0s0841berfvwrn5
 ---
 

--- a/app/docs/CommunityShare/Geek/git101.en.mdx
+++ b/app/docs/CommunityShare/Geek/git101.en.mdx
@@ -3,7 +3,10 @@ title: Git Getting Started Guide — Git Tips Every Developer Should Know
 description: ""
 date: "2025-09-19"
 tags:
-  - tag-one
+  - git-basics
+  - version-control
+  - git-workflow
+  - programmer-essentials
 docId: tksz80mfqqyzwzzer5p3uxtg
 lang: en
 translatedFrom: zh

--- a/app/docs/CommunityShare/Geek/git101.mdx
+++ b/app/docs/CommunityShare/Geek/git101.mdx
@@ -3,7 +3,10 @@ title: Git入门操作指南-程序员必会的git小技巧
 description: ""
 date: "2025-09-19"
 tags:
-  - tag-one
+  - git-basics
+  - version-control
+  - git-workflow
+  - programmer-essentials
 docId: tksz80mfqqyzwzzer5p3uxtg
 ---
 

--- a/app/docs/CommunityShare/Geek/picturecdn.en.mdx
+++ b/app/docs/CommunityShare/Geek/picturecdn.en.mdx
@@ -3,7 +3,10 @@ title: How to Deploy Your Own GitHub Image Hosting with PictureCDN
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - image-hosting
+  - github-pages
+  - cdn
+  - self-hosting
 docId: e6udpzrorhvgeeda6xpy1e0s
 lang: en
 translatedFrom: zh

--- a/app/docs/CommunityShare/Geek/picturecdn.mdx
+++ b/app/docs/CommunityShare/Geek/picturecdn.mdx
@@ -3,7 +3,10 @@ title: 如何部署你自己的Github图床-PictureCDN
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - image-hosting
+  - github-pages
+  - cdn
+  - self-hosting
 docId: e6udpzrorhvgeeda6xpy1e0s
 ---
 

--- a/app/docs/CommunityShare/Life/unsw-student-benefit.md
+++ b/app/docs/CommunityShare/Life/unsw-student-benefit.md
@@ -3,7 +3,10 @@ title: UNSW学费回收计划-那些你还不知道的隐藏福利
 description: ""
 date: "2025-10-03"
 tags:
-  - tag-one
+  - unsw
+  - university-benefits
+  - student-resources
+  - australia-study
 docId: jgyg6bp0nceyrxirz5qw3zsv
 ---
 

--- a/app/docs/CommunityShare/Personal-Study-Notes/Reinforcement-Learning/ppo.md
+++ b/app/docs/CommunityShare/Personal-Study-Notes/Reinforcement-Learning/ppo.md
@@ -3,7 +3,10 @@ title: PPO
 description: ""
 date: "2025-10-03"
 tags:
-  - tag-one
+  - reinforcement-learning
+  - ppo
+  - policy-gradient
+  - gae
 docId: zf8zk108oqbsg56xjyqb5txk
 ---
 

--- a/app/docs/CommunityShare/Personal-Study-Notes/Reinforcement-Learning/ppo.md
+++ b/app/docs/CommunityShare/Personal-Study-Notes/Reinforcement-Learning/ppo.md
@@ -3,10 +3,7 @@ title: PPO
 description: ""
 date: "2025-10-03"
 tags:
-  - reinforcement-learning
-  - ppo
-  - policy-gradient
-  - gae
+  - tag-one
 docId: zf8zk108oqbsg56xjyqb5txk
 ---
 

--- a/app/docs/ai/Introduction-of-Multi-agents-system/introduction_of_multi-agents_system.en.md
+++ b/app/docs/ai/Introduction-of-Multi-agents-system/introduction_of_multi-agents_system.en.md
@@ -3,7 +3,9 @@ title: Introduction of Multi-Agent Systems (For Any Task You Want)
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - multi-agent-systems
+  - agent-framework
+  - llm-agents
 docId: h53uwefhlykt9ietsx9x0vtn
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/Introduction-of-Multi-agents-system/introduction_of_multi-agents_system.md
+++ b/app/docs/ai/Introduction-of-Multi-agents-system/introduction_of_multi-agents_system.md
@@ -3,7 +3,9 @@ title: Introduction of Multi-agents system(In any task you want)
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - multi-agent-systems
+  - agent-framework
+  - llm-agents
 docId: h53uwefhlykt9ietsx9x0vtn
 ---
 

--- a/app/docs/ai/MoE/moe-update.en.md
+++ b/app/docs/ai/MoE/moe-update.en.md
@@ -3,7 +3,9 @@ title: "Theory of MoE"
 description: ""
 date: "2025-10-05"
 tags:
-  - tag-one
+  - mixture-of-experts
+  - model-architecture
+  - llm-fundamentals
 docId: db3qwg25h6l0bh8f2sdabdqc
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/MoE/moe-update.md
+++ b/app/docs/ai/MoE/moe-update.md
@@ -3,7 +3,9 @@ title: "Theory of MoE"
 description: ""
 date: "2025-10-05"
 tags:
-  - tag-one
+  - mixture-of-experts
+  - model-architecture
+  - llm-fundamentals
 docId: db3qwg25h6l0bh8f2sdabdqc
 ---
 

--- a/app/docs/ai/Multi-agents-system-on-Code-Translation/code-translation-intro.en.mdx
+++ b/app/docs/ai/Multi-agents-system-on-Code-Translation/code-translation-intro.en.mdx
@@ -3,7 +3,10 @@ title: Essential Reading for Getting Started with Code Translation
 description: ""
 date: "2025-09-19"
 tags:
-  - tag-one
+  - code-translation
+  - llm-application
+  - paper-recommendations
+  - program-analysis
 docId: qaezsrj15sudk796r5otne36
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/Multi-agents-system-on-Code-Translation/code-translation-intro.mdx
+++ b/app/docs/ai/Multi-agents-system-on-Code-Translation/code-translation-intro.mdx
@@ -3,7 +3,10 @@ title: Code translation入门推荐必读
 description: ""
 date: "2025-09-19"
 tags:
-  - tag-one
+  - code-translation
+  - llm-application
+  - paper-recommendations
+  - program-analysis
 docId: qaezsrj15sudk796r5otne36
 ---
 

--- a/app/docs/ai/ai-math-basics/math_books.en.md
+++ b/app/docs/ai/ai-math-basics/math_books.en.md
@@ -3,7 +3,10 @@ title: Recommended Books on Mathematics and Data Science
 description: ""
 date: "2025-10-06"
 tags:
-  - tag-one
+  - math-textbooks
+  - learning-resources
+  - data-science
+  - book-recommendations
 docId: kzi6k1yg1sehlxidnxdsf59a
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/ai-math-basics/math_books.md
+++ b/app/docs/ai/ai-math-basics/math_books.md
@@ -3,7 +3,10 @@ title: Recommended Books on Mathematics and Data Science
 description: ""
 date: "2025-10-06"
 tags:
-  - tag-one
+  - math-textbooks
+  - learning-resources
+  - data-science
+  - book-recommendations
 docId: kzi6k1yg1sehlxidnxdsf59a
 ---
 

--- a/app/docs/ai/misc-tools/swanlab.en.mdx
+++ b/app/docs/ai/misc-tools/swanlab.en.mdx
@@ -3,7 +3,9 @@ title: SwanLab Quick Start Guide
 description: ""
 date: "2025-09-23"
 tags:
-  - tag-one
+  - ml-experiment-tracking
+  - swanlab
+  - experiment-management
 docId: mhyoknm6vj8jmp186oli5f5c
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/misc-tools/swanlab.mdx
+++ b/app/docs/ai/misc-tools/swanlab.mdx
@@ -3,7 +3,9 @@ title: swanlab快速上手指南
 description: ""
 date: "2025-09-23"
 tags:
-  - tag-one
+  - ml-experiment-tracking
+  - swanlab
+  - experiment-management
 docId: mhyoknm6vj8jmp186oli5f5c
 ---
 

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_crossing.en.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_crossing.en.mdx
@@ -3,7 +3,9 @@ title: Wang Shusen Recommender Systems Study Notes — Feature Crossing
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - feature-engineering
+  - feature-crossing
 docId: hajz43iblku13mmevia8zrhv
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_crossing.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_crossing.mdx
@@ -3,7 +3,9 @@ title: 王树森推荐系统学习笔记_特征交叉
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - feature-engineering
+  - feature-crossing
 docId: hajz43iblku13mmevia8zrhv
 ---
 

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note/wangshusen_recommend_note_retrieval.en.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note/wangshusen_recommend_note_retrieval.en.mdx
@@ -3,7 +3,9 @@ title: Wang Shusen Recommender Systems Study Notes — Retrieval
 description: ""
 date: "2025-09-22"
 tags:
-  - tag-one
+  - recommender-systems
+  - retrieval
+  - candidate-generation
 docId: c3a4nmid9plytif5ameigj7d
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note/wangshusen_recommend_note_retrieval.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note/wangshusen_recommend_note_retrieval.mdx
@@ -3,7 +3,9 @@ title: 王树森推荐系统学习笔记_召回
 description: ""
 date: "2025-09-22"
 tags:
-  - tag-one
+  - recommender-systems
+  - retrieval
+  - candidate-generation
 docId: c3a4nmid9plytif5ameigj7d
 ---
 

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note_coldstart.en.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note_coldstart.en.mdx
@@ -3,7 +3,9 @@ title: Wang Shusen Recommender Systems Study Notes — Cold Start
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - cold-start
+  - new-item-recommendation
 docId: bvccoatft6y7bph83oivdcfe
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note_coldstart.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note_coldstart.mdx
@@ -3,7 +3,9 @@ title: 王树森推荐系统学习笔记_冷启动
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - cold-start
+  - new-item-recommendation
 docId: bvccoatft6y7bph83oivdcfe
 ---
 

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note_improvement.en.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note_improvement.en.mdx
@@ -3,7 +3,10 @@ title: Wang Shusen Recommender Systems Study Notes — Improving Metrics
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - metric-optimization
+  - retention-metrics
+  - user-growth
 docId: qmy3p4vc45ek61ce4n62fpxy
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note_improvement.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note_improvement.mdx
@@ -3,7 +3,10 @@ title: 王树森推荐系统学习笔记_涨指标
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - metric-optimization
+  - retention-metrics
+  - user-growth
 docId: qmy3p4vc45ek61ce4n62fpxy
 ---
 

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note_rank.en.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note_rank.en.mdx
@@ -3,7 +3,9 @@ title: Wang Shusen Recommender Systems Study Notes — Ranking
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - ranking
+  - learning-to-rank
 docId: vjwogf9afghpbvi71e4dfsgj
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note_rank.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note_rank.mdx
@@ -3,7 +3,9 @@ title: 王树森推荐系统学习笔记_排序
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - ranking
+  - learning-to-rank
 docId: vjwogf9afghpbvi71e4dfsgj
 ---
 

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note_rerank.en.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note_rerank.en.mdx
@@ -3,7 +3,9 @@ title: Wang Shusen Recommender Systems Study Notes — Re-Ranking
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - reranking
+  - diversity
 docId: ol03smbujgwztho45ycj52ah
 lang: en
 translatedFrom: zh

--- a/app/docs/ai/recommender-systems/wangshusen_recommend_note_rerank.mdx
+++ b/app/docs/ai/recommender-systems/wangshusen_recommend_note_rerank.mdx
@@ -3,7 +3,9 @@ title: 王树森推荐系统学习笔记_重排
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - recommender-systems
+  - reranking
+  - diversity
 docId: ol03smbujgwztho45ycj52ah
 ---
 

--- a/app/docs/computer-science/cpp_backend/Handwritten_pool_components/1_Handwritten_threadpool.en.md
+++ b/app/docs/computer-science/cpp_backend/Handwritten_pool_components/1_Handwritten_threadpool.en.md
@@ -3,7 +3,9 @@ title: Handwritten Thread Pool
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - threadpool
+  - concurrent-programming
 docId: mnjkrtrs7xk3fq538eqreuge
 lang: en
 translatedFrom: zh

--- a/app/docs/computer-science/cpp_backend/Handwritten_pool_components/1_Handwritten_threadpool.md
+++ b/app/docs/computer-science/cpp_backend/Handwritten_pool_components/1_Handwritten_threadpool.md
@@ -3,7 +3,9 @@ title: 手写线程池
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - threadpool
+  - concurrent-programming
 docId: mnjkrtrs7xk3fq538eqreuge
 ---
 

--- a/app/docs/computer-science/cpp_backend/Handwritten_pool_components/2_Handwritten_mempool1.en.md
+++ b/app/docs/computer-science/cpp_backend/Handwritten_pool_components/2_Handwritten_mempool1.en.md
@@ -3,7 +3,9 @@ title: Handwritten Fixed-Size Memory Pool
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - memory-pool
+  - system-programming
 docId: xgxqqvglxyauoeh8eye7lzu6
 lang: en
 translatedFrom: zh

--- a/app/docs/computer-science/cpp_backend/Handwritten_pool_components/2_Handwritten_mempool1.md
+++ b/app/docs/computer-science/cpp_backend/Handwritten_pool_components/2_Handwritten_mempool1.md
@@ -3,7 +3,9 @@ title: 手写定长内存池
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - memory-pool
+  - system-programming
 docId: xgxqqvglxyauoeh8eye7lzu6
 ---
 

--- a/app/docs/computer-science/cpp_backend/easy_compile/1_cpp_libs.en.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/1_cpp_libs.en.md
@@ -3,7 +3,9 @@ title: C++ Libraries on Linux/Windows
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - cpp-libraries
+  - development-environment
 docId: totx4pej5lhyt1nl4anwhakj
 lang: en
 translatedFrom: zh

--- a/app/docs/computer-science/cpp_backend/easy_compile/1_cpp_libs.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/1_cpp_libs.md
@@ -3,7 +3,9 @@ title: linux/win上的c++库
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - cpp-libraries
+  - development-environment
 docId: totx4pej5lhyt1nl4anwhakj
 ---
 

--- a/app/docs/computer-science/cpp_backend/easy_compile/2_base_gcc.en.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/2_base_gcc.en.md
@@ -3,7 +3,9 @@ title: GCC/G++ Basics
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - gcc
+  - compiler-toolchain
 docId: kyu85av71b4n07hbdycbhvj9
 lang: en
 translatedFrom: zh

--- a/app/docs/computer-science/cpp_backend/easy_compile/2_base_gcc.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/2_base_gcc.md
@@ -3,7 +3,9 @@ title: 基础gcc/g++
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - gcc
+  - compiler-toolchain
 docId: kyu85av71b4n07hbdycbhvj9
 ---
 

--- a/app/docs/computer-science/cpp_backend/easy_compile/3_Make.en.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/3_Make.en.md
@@ -3,7 +3,9 @@ title: Building with Make
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - makefile
+  - build-system
 docId: g6wucmr69lamd9xyxm7uunnd
 lang: en
 translatedFrom: zh

--- a/app/docs/computer-science/cpp_backend/easy_compile/3_Make.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/3_Make.md
@@ -3,7 +3,9 @@ title: Make编译
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - makefile
+  - build-system
 docId: g6wucmr69lamd9xyxm7uunnd
 ---
 

--- a/app/docs/computer-science/cpp_backend/easy_compile/4_CMake.en.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/4_CMake.en.md
@@ -3,7 +3,9 @@ title: CMake
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - cmake
+  - build-system
 docId: xk44lx4q1gpcm1uqk8nnbg7q
 lang: en
 translatedFrom: zh

--- a/app/docs/computer-science/cpp_backend/easy_compile/4_CMake.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/4_CMake.md
@@ -3,7 +3,9 @@ title: CMake
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - cmake
+  - build-system
 docId: xk44lx4q1gpcm1uqk8nnbg7q
 ---
 

--- a/app/docs/computer-science/cpp_backend/easy_compile/5_vcpkg.en.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/5_vcpkg.en.md
@@ -3,7 +3,9 @@ title: vcpkg Package Manager
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - vcpkg
+  - package-manager
 docId: gtqamuq3tftmvzstbunkgbo5
 lang: en
 translatedFrom: zh

--- a/app/docs/computer-science/cpp_backend/easy_compile/5_vcpkg.md
+++ b/app/docs/computer-science/cpp_backend/easy_compile/5_vcpkg.md
@@ -3,7 +3,9 @@ title: vcpkg包管理器
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - cpp-backend
+  - vcpkg
+  - package-manager
 docId: gtqamuq3tftmvzstbunkgbo5
 ---
 

--- a/app/docs/computer-science/cpp_backend/mempool_simple.en.mdx
+++ b/app/docs/computer-science/cpp_backend/mempool_simple.en.mdx
@@ -3,7 +3,9 @@ title: Handwritten Memory Pool (Simple Fixed-Size)
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - cpp-backend
+  - memory-pool
+  - memory-management
 docId: q8290wmhyofuiskzn1ph63ta
 lang: en
 translatedFrom: zh

--- a/app/docs/computer-science/cpp_backend/mempool_simple.mdx
+++ b/app/docs/computer-science/cpp_backend/mempool_simple.mdx
@@ -3,7 +3,9 @@ title: 手写内存池（简单定长）
 description: ""
 date: "2025-09-27"
 tags:
-  - tag-one
+  - cpp-backend
+  - memory-pool
+  - memory-management
 docId: q8290wmhyofuiskzn1ph63ta
 ---
 

--- a/app/docs/jobs/event-keynote/coffee-chat.en.md
+++ b/app/docs/jobs/event-keynote/coffee-chat.en.md
@@ -3,7 +3,12 @@ title: Senior Tech-Industry Engineer Coffee Chat Recap
 description: ""
 date: "2025-11-01"
 tags:
-  - tag-one
+  - career
+  - networking
+  - tech-industry
+  - australia-job-market
+  - career-path
+  - sre
 docId: ld59a8z1v84ig4rlr0p0n2a9
 lang: en
 translatedFrom: zh

--- a/app/docs/jobs/event-keynote/coffee-chat.md
+++ b/app/docs/jobs/event-keynote/coffee-chat.md
@@ -3,7 +3,12 @@ title: 资深科技大厂程序员Coffee Chat回顾
 description: ""
 date: "2025-11-01"
 tags:
-  - tag-one
+  - career
+  - networking
+  - tech-industry
+  - australia-job-market
+  - career-path
+  - sre
 docId: ld59a8z1v84ig4rlr0p0n2a9
 ---
 

--- a/app/docs/jobs/interview-prep/interview-tips.en.mdx
+++ b/app/docs/jobs/interview-prep/interview-tips.en.mdx
@@ -3,7 +3,11 @@ title: "Conquering Every Interview Stage | OA Coding Grind, HireVue Score Tricks
 description: ""
 date: "2025-09-19"
 tags:
-  - tag-one
+  - interview-preparation
+  - online-assessment
+  - video-interview
+  - group-interview
+  - australia-job-market
 docId: fkk8ghklsr15a0s3vcxnswnj
 lang: en
 translatedFrom: zh

--- a/app/docs/jobs/interview-prep/interview-tips.mdx
+++ b/app/docs/jobs/interview-prep/interview-tips.mdx
@@ -3,7 +3,11 @@ title: "面试阶段逐关击破 | OA刷题血泪史 + VI分数偷看技巧 + �
 description: ""
 date: "2025-09-19"
 tags:
-  - tag-one
+  - interview-preparation
+  - online-assessment
+  - video-interview
+  - group-interview
+  - australia-job-market
 docId: fkk8ghklsr15a0s3vcxnswnj
 ---
 

--- a/app/docs/jobs/interview-prep/pre-interview.en.md
+++ b/app/docs/jobs/interview-prep/pre-interview.en.md
@@ -3,7 +3,8 @@ title: "Must-Read Before Your Interview: Four Tips That Significantly Boost Your
 description: ""
 date: "2025-09-28"
 tags:
-  - tag-one
+  - interview-preparation
+  - career
 docId: cgo4lweflk5jx1hsncr8hshk
 lang: en
 translatedFrom: zh

--- a/app/docs/jobs/interview-prep/pre-interview.md
+++ b/app/docs/jobs/interview-prep/pre-interview.md
@@ -3,7 +3,8 @@ title: " 面试前必看：掌握这四个小技巧，你的成功率会大大�
 description: ""
 date: "2025-09-28"
 tags:
-  - tag-one
+  - interview-preparation
+  - career
 docId: cgo4lweflk5jx1hsncr8hshk
 ---
 

--- a/app/docs/jobs/interview-prep/preparations-to-get-an-offer-as-a-student.en.mdx
+++ b/app/docs/jobs/interview-prep/preparations-to-get-an-offer-as-a-student.en.mdx
@@ -3,7 +3,10 @@ title: A Programmer's Guide to Job Searching and Internships as a Student
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - internship
+  - job-search
+  - new-grad
+  - student-career
 docId: pne40puz5alzsf0f5jb0frbm
 lang: en
 translatedFrom: zh

--- a/app/docs/jobs/interview-prep/preparations-to-get-an-offer-as-a-student.mdx
+++ b/app/docs/jobs/interview-prep/preparations-to-get-an-offer-as-a-student.mdx
@@ -3,7 +3,10 @@ title: 程序员学生时期求职与实习经验分享
 description: ""
 date: "2025-09-29"
 tags:
-  - tag-one
+  - internship
+  - job-search
+  - new-grad
+  - student-career
 docId: pne40puz5alzsf0f5jb0frbm
 ---
 


### PR DESCRIPTION
## 背景

站点早期模板带 `tag-one` 作为 frontmatter.tags 的默认占位符，30 份文档至今没覆盖。tags 字段影响 sidebar 显示、未来的 tag 筛选 UI、SEO 结构化数据。批量清理。

## 作用域

- **28 份原文 + 26 份 `.en` 翻译 = 54 个文件** 全部更新 tags
- **跳过 PR #307 已在处理的 4 份**（rag / embedding / context-eng / ai-town），由那个 PR 负责清理，合并顺序无关
- **纯文本改动，零 URL 变化，无需 301 redirects**
- **docId 全部原样保留**，sync-uuid 合并后不会误判为新文档

## 流程

1. **Scan**: grep `  - tag-one` 找出 30 个原文
2. **草拟**: 按目录语义分类给 3-5 个 tags
3. **Reviewer subagent 审稿**: 读每份文档前 50 行，挑出 9 处需修正（rlhf/abtest 等与正文不符的 tag、命名一致性问题、路径词误当 tag），**全部采纳**
4. **Python 原子替换**: 脚本一把梭，每次替换前检查 `  - tag-one` 存在、读取全文、replace、写回
5. **校验**: grep 残留仅剩 PR #307 的 4 个文件

## 标签分类覆盖

| 目录 | 代表 tags |
|------|----------|
| `CommunityShare/Geek/` | image-hosting, self-hosting, cdn, git-workflow |
| `CommunityShare/Life/` | unsw, university-benefits, australia-study |
| `CommunityShare/Personal-Study-Notes/` | reinforcement-learning, ppo, gae |
| `ai/Introduction-of-Multi-agents-system/` | multi-agent-systems, agent-framework |
| `ai/MoE/` | mixture-of-experts, model-architecture |
| `ai/Multi-agents-system-on-Code-Translation/` | code-translation, llm-application |
| `ai/ai-math-basics/` | math-textbooks, learning-resources, book-recommendations |
| `ai/misc-tools/` | ml-experiment-tracking, swanlab |
| `ai/recommender-systems/` (6 份王树森笔记) | recommender-systems + feature-crossing / retrieval / cold-start / ranking / reranking / metric-optimization |
| `computer-science/cpp_backend/` (8 份) | cpp-backend + threadpool / memory-pool / build-system / gcc / cmake / vcpkg |
| `jobs/` | career, interview-preparation, internship, australia-job-market |

## Reviewer 捕捉的 9 个修正（已采纳）

1. `ppo.md`: `rlhf` → `gae`（正文没提 RLHF，明确讨论 GAE 优势估计）
2. `code-translation-intro.mdx`: 不是 multi-agent，是 paper reading list → 去掉 multi-agent-systems，加 paper-recommendations
3. `math_books.md`: 去 `ai-math-basics`（太像路径），加 `data-science, book-recommendations`
4. `wangshusen_recommend_note_coldstart`: `new-user-items` → `new-item-recommendation`
5. `wangshusen_recommend_note_improvement`: 文档讲 DAU/LT7 留存指标，`abtest` 不准 → `retention-metrics, user-growth`
6. `coffee-chat.md`: 涵盖澳洲求职 + SRE 路径，补 `australia-job-market, career-path, sre`，去 `mentorship`
7. `interview-tips.mdx`: 补 `australia-job-market`（和 coffee-chat 一致）
8. 命名一致性: 去掉 `interview-techniques` 用 `interview-preparation`；`new-grad-career` → `new-grad`
9. `preparations-to-get-an-offer`: 涵盖 TA/RA/Hackathon，补 `student-career`

## 测试计划

- [x] `pnpm typecheck` 通过
- [x] `grep "  - tag-one"` 残留仅 4 个（PR #307 覆盖）
- [x] docId 守恒（Python 脚本只改 tags 行）
- [ ] 合 main 后 sync-uuid 跑通（本 PR tags 改动不影响 docId 归属）
- [ ] Vercel preview 翻开几份看 sidebar / 页面标签是否正确展示

## 合并顺序

和 PR #307 独立，先合哪个都行。**建议先合 #307**（风险更高的结构调整先 burn-in），再合本 PR。