### PR TITLE
feat(community): 社区分享链接墙前端 M5-M10（/feed + i18n + 管理面板）

### DIFF
--- a/app/admin/community/layout.tsx
+++ b/app/admin/community/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+/**
+ * /admin/community/* 子树的 layout。
+ *
+ * 根 /admin/layout.tsx 已经挂了 Header / Footer，这层仅透传。
+ * 保留文件是让 Next 路由分段能命中，必要时在这里插入 community 专属的 Tab / sidebar。
+ */
+export default function AdminCommunityLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/admin/community/lib.ts
+++ b/app/admin/community/lib.ts
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * Admin 侧 Community 的 API client（纯 client）。
+ *
+ * 参照 /admin/events/lib.ts 的做法：
+ * - 所有请求带 satoken header（从 localStorage 读）
+ * - 响应统一解包后端 ApiResponse<T>
+ *
+ * 对应后端：/api/admin/community/*  （走 @SaCheckRole("admin")）
+ */
+
+import type { SharedLinkView } from "@/app/feed/types";
+
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+function token(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("satoken");
+}
+
+async function request<T>(url: string, init: RequestInit = {}): Promise<T> {
+  const t = token();
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      ...(t ? { satoken: t } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+  const json = (await res.json()) as ApiResponse<T>;
+  if (!res.ok || !json.success) {
+    throw new Error(json.message ?? `请求失败 ${res.status}`);
+  }
+  if (json.data === undefined) {
+    throw new Error("后端返回 success 但没有 data");
+  }
+  return json.data;
+}
+
+/** 拉取管理员待审列表（PENDING_MANUAL + FLAGGED） */
+export function listPendingLinks(): Promise<SharedLinkView[]> {
+  return request<SharedLinkView[]>("/api/admin/community/pending");
+}
+
+/** 通过一条链接，状态置 APPROVED */
+export function approveLink(id: number): Promise<SharedLinkView> {
+  return request<SharedLinkView>(`/api/admin/community/${id}/approve`, {
+    method: "POST",
+  });
+}
+
+/** 拒绝一条链接，状态置 REJECTED */
+export function rejectLink(
+  id: number,
+  reason?: string,
+): Promise<SharedLinkView> {
+  return request<SharedLinkView>(`/api/admin/community/${id}/reject`, {
+    method: "POST",
+    body: JSON.stringify({ reason: reason ?? null }),
+  });
+}

--- a/app/admin/community/page.tsx
+++ b/app/admin/community/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/**
+ * /admin/community — 管理员审核社区分享链接。
+ *
+ * 权限：包在 <AdminGuard> 里。
+ * 数据：GET /api/admin/community/pending 拉 PENDING_MANUAL + FLAGGED 两种状态。
+ * 交互：每条两个动作——通过（→ APPROVED）/ 拒绝（→ REJECTED）。
+ *
+ * 为什么不用复杂表格：v1 预计审核频率很低（每周一次扫），
+ * 简单的卡片列表加两按钮足矣；后续量大了再做分页 + 批量操作。
+ */
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { AdminGuard } from "@/app/admin/events/AdminGuard";
+import type { SharedLinkView } from "@/app/feed/types";
+import { approveLink, listPendingLinks, rejectLink } from "./lib";
+
+export default function AdminCommunityPage() {
+  return (
+    <AdminGuard>
+      <AdminCommunityInner />
+    </AdminGuard>
+  );
+}
+
+// FLAGGED 的原因标签（来自后端 AI 判定的 flags JSON）
+function renderFlagBadges(link: SharedLinkView) {
+  // flags 目前前端 DTO 里没直接暴露，这里预留位——M7 后端返回 flags 后再补
+  if (link.status !== "FLAGGED") return null;
+  return (
+    <span className="rounded-full bg-red-100 text-red-900 px-2 py-0.5 text-xs font-medium">
+      AI 判定需要复核
+    </span>
+  );
+}
+
+function AdminCommunityInner() {
+  const [links, setLinks] = useState<SharedLinkView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // 记录正在处理的 link id，避免一条链接按两次
+  const [workingId, setWorkingId] = useState<number | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setLinks(await listPendingLinks());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "加载失败");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const onApprove = async (id: number) => {
+    setWorkingId(id);
+    try {
+      await approveLink(id);
+      // 审核后直接从列表中移除（通过的不再出现在待审）
+      setLinks((xs) => xs.filter((x) => x.id !== id));
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "通过失败");
+    } finally {
+      setWorkingId(null);
+    }
+  };
+
+  const onReject = async (id: number) => {
+    const reason = prompt("拒绝原因（可选，留空直接拒绝）：") ?? undefined;
+    setWorkingId(id);
+    try {
+      await rejectLink(id, reason || undefined);
+      setLinks((xs) => xs.filter((x) => x.id !== id));
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "拒绝失败");
+    } finally {
+      setWorkingId(null);
+    }
+  };
+
+  return (
+    <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
+      <div className="max-w-6xl mx-auto px-6 lg:px-8">
+        <header className="border-t-4 border-[var(--foreground)] pt-6 mb-10">
+          <div className="font-mono text-[10px] uppercase tracking-[0.3em] text-neutral-500">
+            Admin · Community
+          </div>
+          <h1 className="font-serif text-3xl md:text-4xl font-black uppercase mt-2 tracking-tight">
+            社区分享审核
+          </h1>
+          <p className="mt-3 text-sm text-neutral-500">
+            这里列出所有 PENDING_MANUAL（非白名单域名）和 FLAGGED（AI 判定风险）
+            的链接。审核频率预期很低（每周一次），按需处理即可。
+          </p>
+        </header>
+
+        {loading && <p className="text-sm text-neutral-500">加载中...</p>}
+
+        {error && (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+            加载失败：{error}
+            <button
+              className="ml-3 underline"
+              type="button"
+              onClick={() => void load()}
+            >
+              重试
+            </button>
+          </div>
+        )}
+
+        {!loading && !error && links.length === 0 && (
+          <div className="rounded-lg border border-dashed p-10 text-center text-sm text-neutral-500">
+            当前没有需要审核的链接。
+          </div>
+        )}
+
+        {!loading && links.length > 0 && (
+          <ul className="space-y-4">
+            {links.map((link) => (
+              <li
+                key={link.id}
+                className="border border-[var(--foreground)]/40 p-4 flex flex-col md:flex-row gap-4"
+              >
+                {/* 左：OG 封面缩略图（没抓到就占位） */}
+                <div className="w-full md:w-40 aspect-[16/9] flex-shrink-0 bg-neutral-100 dark:bg-neutral-900 relative overflow-hidden">
+                  {link.ogCover ? (
+                    <Image
+                      src={link.ogCover}
+                      alt={link.ogTitle ?? link.url}
+                      fill
+                      sizes="160px"
+                      className="object-cover"
+                      unoptimized
+                    />
+                  ) : (
+                    <span className="absolute inset-0 flex items-center justify-center text-3xl font-bold text-neutral-400">
+                      {link.host[0]?.toUpperCase() ?? "?"}
+                    </span>
+                  )}
+                </div>
+
+                {/* 中：元信息 */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                        link.status === "FLAGGED"
+                          ? "bg-red-100 text-red-900"
+                          : "bg-orange-100 text-orange-900"
+                      }`}
+                    >
+                      {link.status === "FLAGGED" ? "AI 标记" : "非白名单"}
+                    </span>
+                    {renderFlagBadges(link)}
+                    <span className="text-xs text-neutral-500 font-mono">
+                      {link.host}
+                    </span>
+                  </div>
+                  <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block mt-2 font-semibold text-base hover:underline truncate"
+                    title={link.ogTitle ?? link.url}
+                  >
+                    {link.ogTitle ?? link.url}
+                  </a>
+                  {link.ogDescription && (
+                    <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">
+                      {link.ogDescription}
+                    </p>
+                  )}
+                  {link.recommendation && (
+                    <p className="mt-2 text-xs text-neutral-500 italic">
+                      推荐：{link.recommendation}
+                    </p>
+                  )}
+                  <p className="mt-2 text-xs text-neutral-400">
+                    提交人 #{link.submitterId} ·{" "}
+                    {new Date(link.createdAt).toLocaleString()}
+                  </p>
+                </div>
+
+                {/* 右：操作按钮 */}
+                <div className="flex md:flex-col gap-2 md:w-32 md:flex-shrink-0">
+                  <button
+                    type="button"
+                    disabled={workingId === link.id}
+                    onClick={() => void onApprove(link.id)}
+                    className="flex-1 px-3 py-2 text-sm font-mono uppercase tracking-wider bg-[var(--foreground)] text-[var(--background)] hover:bg-emerald-600 transition-colors disabled:opacity-50"
+                  >
+                    {workingId === link.id ? "..." : "通过"}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={workingId === link.id}
+                    onClick={() => void onReject(link.id)}
+                    className="flex-1 px-3 py-2 text-sm font-mono uppercase tracking-wider border border-[var(--foreground)] hover:bg-[#CC0000] hover:text-white hover:border-[#CC0000] transition-colors disabled:opacity-50"
+                  >
+                    拒绝
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/admin/community/page.tsx
+++ b/app/admin/community/page.tsx
@@ -15,6 +15,7 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import { AdminGuard } from "@/app/admin/events/AdminGuard";
 import type { SharedLinkView } from "@/app/feed/types";
+import { sanitizeExternalUrl } from "@/lib/url-safety";
 import { approveLink, listPendingLinks, rejectLink } from "./lib";
 
 export default function AdminCommunityPage() {
@@ -164,15 +165,30 @@ function AdminCommunityInner() {
                       {link.host}
                     </span>
                   </div>
-                  <a
-                    href={link.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block mt-2 font-semibold text-base hover:underline truncate"
-                    title={link.ogTitle ?? link.url}
-                  >
-                    {link.ogTitle ?? link.url}
-                  </a>
+                  {(() => {
+                    // defense-in-depth：后端 UrlNormalizer 已拒非 http/https，
+                    // 前端仍用 sanitizeExternalUrl 兜底过滤 javascript:/data: 协议。
+                    const safe = sanitizeExternalUrl(link.url);
+                    const title = link.ogTitle ?? link.url;
+                    return safe ? (
+                      <a
+                        href={safe}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block mt-2 font-semibold text-base hover:underline truncate"
+                        title={title}
+                      >
+                        {title}
+                      </a>
+                    ) : (
+                      <span
+                        className="block mt-2 font-semibold text-base text-neutral-400 truncate"
+                        title="链接协议不安全，已禁用点击"
+                      >
+                        {title} ⚠
+                      </span>
+                    );
+                  })()}
                   {link.ogDescription && (
                     <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">
                       {link.ogDescription}

--- a/app/components/Contribute.tsx
+++ b/app/components/Contribute.tsx
@@ -162,7 +162,8 @@ export function Contribute() {
         }
       }}
     >
-      <div className="relative mt-12 inline-flex w-full sm:w-auto">
+      {/* mt 由外层容器控制；本组件只负责按钮 + 徽章的相对定位 */}
+      <div className="relative inline-flex w-full sm:w-auto">
         <DialogTrigger asChild>
           <Button
             variant="hero"

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -66,6 +66,16 @@ export async function Hero() {
 
               <div className="mt-12">
                 <Contribute />
+                {/* 次级文字链：层级明显低于主 CTA，斜体小字，不抢夺视觉焦点 */}
+                <Link
+                  href="/feed"
+                  className="mt-4 inline-block text-sm italic text-muted-foreground hover:text-[var(--foreground)] transition-colors duration-200"
+                  data-umami-event="navigation_click"
+                  data-umami-event-region="hero_feed_entry"
+                  data-umami-event-label="feed link"
+                >
+                  {t("feedLink")}
+                </Link>
               </div>
             </div>
           </div>

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import ZoteroFeedLazy from "@/app/components/ZoteroFeedLazy";
 import { Contribute } from "@/app/components/Contribute";
+import { ShareLink } from "@/app/components/ShareLink";
 import Image from "next/image";
 import { ActivityTicker } from "@/app/components/ActivityTicker";
 import { cn } from "@/lib/utils";
@@ -64,18 +65,11 @@ export async function Hero() {
                 {t("mission")}
               </p>
 
-              <div className="mt-12">
+              {/* 双 CTA 并排：Contribute（正式投稿 Fumadocs）+ ShareLink（随手分享外部文章到 /feed）
+                  两者视觉平级，移动端堆叠（flex-wrap），桌面并排（gap-6） */}
+              <div className="mt-12 flex flex-wrap items-start gap-x-6 gap-y-8">
                 <Contribute />
-                {/* 次级文字链：层级明显低于主 CTA，斜体小字，不抢夺视觉焦点 */}
-                <Link
-                  href="/feed"
-                  className="mt-4 inline-block text-sm italic text-muted-foreground hover:text-[var(--foreground)] transition-colors duration-200"
-                  data-umami-event="navigation_click"
-                  data-umami-event-region="hero_feed_entry"
-                  data-umami-event-label="feed link"
-                >
-                  {t("feedLink")}
-                </Link>
+                <ShareLink />
               </div>
             </div>
           </div>

--- a/app/components/ShareLink.tsx
+++ b/app/components/ShareLink.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Hero 区的"分享链接"按钮。
+ *
+ * 视觉与样式**完全复制** Contribute 主 CTA，和它并排形成双 CTA：
+ * - Contribute → 正式投稿 Fumadocs 知识库（走 GitHub PR）
+ * - ShareLink  → 随手分享公众号/知乎等文章到社区墙（/feed）
+ *
+ * 两者语义平级，视觉也平级——这是用户拍板的设计（之前尝试的次级文字链 UI 不够突出）。
+ * 按钮点击跳 /feed（先看一眼再决定是否提交），右上角徽章保留与 Contribute 对称的图标位。
+ */
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Link2, Plus } from "lucide-react";
+
+export function ShareLink() {
+  const t = useTranslations("shareLink");
+
+  return (
+    <div className="relative inline-flex w-full sm:w-auto">
+      {/* 主按钮跳 /feed（社区分享墙），样式与 Contribute 主按钮完全同构 */}
+      <Link
+        href="/feed"
+        className="w-full sm:w-auto"
+        data-umami-event="share_link_trigger"
+        data-umami-event-location="hero"
+      >
+        <Button
+          variant="hero"
+          size="lg"
+          className="relative isolate w-full sm:w-auto h-20 px-14 rounded-none
+                     text-2xl font-serif font-black uppercase italic tracking-tighter
+                     bg-[var(--foreground)] text-[var(--background)] border border-[var(--foreground)]
+                     hover:bg-[var(--background)] hover:text-[var(--foreground)] transition-all duration-300"
+        >
+          <span className="relative z-10 flex items-center gap-4">
+            <Link2 className="h-6 w-6" />
+            <span>{t("button")}</span>
+          </span>
+        </Button>
+      </Link>
+      {/* 右上角徽章：跳 /feed/submit 直接开提交表单，对应 Contribute 的指南 "?" 徽章 */}
+      <Link
+        href="/feed/submit"
+        aria-label={t("submitAriaLabel")}
+        title={t("submitAriaLabel")}
+        className="absolute top-0 right-0 flex h-10 w-10 translate-x-1/2 -translate-y-1/2 items-center justify-center border border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)] font-mono hover:bg-[#CC0000] hover:text-white transition-colors z-20"
+        data-umami-event="share_link_submit_shortcut"
+      >
+        <Plus className="h-4 w-4" strokeWidth={3} />
+        <span className="sr-only">{t("submitAriaLabel")}</span>
+      </Link>
+    </div>
+  );
+}

--- a/app/feed/components/CategoryTabs.tsx
+++ b/app/feed/components/CategoryTabs.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+/**
+ * 分类 tab 导航组件。
+ * 通过 URL searchParams（?category=<slug>）来控制当前选中项，
+ * 保持 SSR 可读且可书签化，避免纯 client state 无法分享链接。
+ */
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { type CategorySlug, CATEGORY_SLUGS } from "@/app/feed/types";
+import { cn } from "@/lib/utils";
+
+export function CategoryTabs() {
+  const t = useTranslations("feed.category");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // 当前选中的分类 slug，空字符串代表"全部"
+  const current = (searchParams.get("category") ?? "") as CategorySlug | "";
+
+  /**
+   * 点击分类时更新 URL query，不需要 push history stack——
+   * 用 replace 避免用户反复点分类时返回键卡死。
+   */
+  function handleSelect(slug: CategorySlug | "") {
+    const params = new URLSearchParams(searchParams.toString());
+    if (slug) {
+      params.set("category", slug);
+    } else {
+      params.delete("category");
+    }
+    router.replace(`/feed?${params.toString()}`);
+  }
+
+  const allTabs: Array<{ slug: CategorySlug | ""; label: string }> = [
+    { slug: "", label: t("all") },
+    ...CATEGORY_SLUGS.map((slug) => ({
+      slug,
+      label: t(slug),
+    })),
+  ];
+
+  return (
+    // 横向滚动容器，移动端展示全部分类时不截断
+    <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-none">
+      {allTabs.map(({ slug, label }) => (
+        <button
+          key={slug || "__all__"}
+          onClick={() => handleSelect(slug)}
+          className={cn(
+            // 基础样式：小号等宽字体，边框按钮形态
+            "shrink-0 px-3 py-1.5 font-mono text-xs uppercase tracking-widest border transition-colors duration-150 whitespace-nowrap",
+            current === slug
+              ? // 选中态：反色高亮
+                "bg-[var(--foreground)] text-[var(--background)] border-[var(--foreground)]"
+              : // 未选中态：透明背景，hover 轻高亮
+                "border-[var(--foreground)]/40 text-neutral-500 hover:border-[var(--foreground)] hover:text-[var(--foreground)]",
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/feed/components/FeedAuthWrapper.tsx
+++ b/app/feed/components/FeedAuthWrapper.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * FeedAuthWrapper —— client 组件桥接器。
+ *
+ * /feed/page.tsx 是 SSR server component，无法感知 localStorage 登录态；
+ * 本组件在 client 端读取 useAuth() 后，把 isLoggedIn 传给 LinkCard，
+ * 使举报按钮可以区分已登录 / 未登录行为。
+ *
+ * 接收 server 端已预计算好的 links 和 categoryLabel 函数，
+ * 只负责登录态桥接，不做额外数据请求。
+ */
+
+import { useAuth } from "@/lib/use-auth";
+import { LinkCard } from "@/app/feed/components/LinkCard";
+import type { SharedLinkView, CategorySlug } from "@/app/feed/types";
+
+interface FeedAuthWrapperProps {
+  links: SharedLinkView[];
+  /** 由 server 端传入的分类标签计算函数（已含 i18n 翻译） */
+  getCategoryLabel: (slug: CategorySlug | null) => string;
+}
+
+export function FeedAuthWrapper({
+  links,
+  getCategoryLabel,
+}: FeedAuthWrapperProps) {
+  const { status } = useAuth();
+  // loading 阶段默认视为未登录，避免 UI 闪烁
+  const isLoggedIn = status === "authenticated";
+
+  return (
+    // 响应式 grid：桌面 3 列 / 平板 2 列 / 手机 1 列
+    <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {links.map((link) => (
+        <LinkCard
+          key={link.id}
+          link={link}
+          categoryLabel={getCategoryLabel(link.category)}
+          isLoggedIn={isLoggedIn}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/app/feed/components/LinkCard.tsx
+++ b/app/feed/components/LinkCard.tsx
@@ -1,0 +1,116 @@
+/**
+ * 社区分享链接卡片。
+ * - 整卡可点击，跳转到原文（target="_blank"）
+ * - OG 封面：有则显示，没有则渲染 host 首字母占位块
+ * - 举报按钮由 ReportButton 组件负责，阻止冒泡不触发整卡跳转
+ * - 服务端渲染（纯展示，无 client state），ReportButton 是 client 组件
+ */
+
+import { useTranslations } from "next-intl";
+import type { SharedLinkView } from "@/app/feed/types";
+import { ReportButton } from "@/app/feed/components/ReportButton";
+import { Badge } from "@/components/ui/badge";
+
+interface LinkCardProps {
+  link: SharedLinkView;
+  /** 分类显示名（由父组件从 i18n 翻译后传入，避免在纯 server 组件里调 useTranslations） */
+  categoryLabel: string;
+  /** 当前用户是否已登录（影响举报按钮行为） */
+  isLoggedIn: boolean;
+}
+
+/** 从 host 字符串提取首字母大写，作为封面占位符 */
+function getHostInitial(host: string): string {
+  const cleaned = host.replace(/^www\./, "");
+  return (cleaned[0] ?? "?").toUpperCase();
+}
+
+export function LinkCard({ link, categoryLabel, isLoggedIn }: LinkCardProps) {
+  const t = useTranslations("feed.card");
+
+  return (
+    <li className="group border border-[var(--foreground)] hover:border-[#CC0000] transition-colors duration-150 flex flex-col">
+      {/* 整卡可点击区域，跳到原文 */}
+      <a
+        href={link.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex flex-col flex-1"
+        aria-label={link.ogTitle ?? link.url}
+      >
+        {/* OG 封面 / 占位块 */}
+        {link.ogCover && !link.ogFetchFailed ? (
+          // next/image 全站 unoptimized:true，用 img 即可（与 events 页一致）
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={link.ogCover}
+            alt={link.ogTitle ?? link.host}
+            className="w-full aspect-[16/9] object-cover border-b border-[var(--foreground)]"
+          />
+        ) : (
+          // 无封面：显示 host 首字母占位
+          <div className="w-full aspect-[16/9] bg-neutral-100 dark:bg-neutral-900 border-b border-[var(--foreground)] flex flex-col items-center justify-center gap-1">
+            <span className="font-serif text-4xl font-black text-neutral-400 select-none">
+              {getHostInitial(link.host)}
+            </span>
+            <span className="font-mono text-[9px] uppercase tracking-widest text-neutral-400">
+              {link.host}
+            </span>
+            {link.ogFetchFailed && (
+              // OG 抓取失败时给用户一个弱提示
+              <span className="font-mono text-[9px] text-neutral-400 mt-1">
+                {t("ogFallback")}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* 卡片内容区 */}
+        <div className="p-4 flex flex-col gap-2 flex-1">
+          {/* 标题 */}
+          <h3 className="font-serif text-base font-black leading-snug group-hover:text-[#CC0000] transition-colors line-clamp-2 text-[var(--foreground)]">
+            {link.ogTitle ?? link.url}
+          </h3>
+
+          {/* OG 描述 / 用户推荐语 */}
+          {(link.recommendation || link.ogDescription) && (
+            <p className="text-sm text-neutral-600 dark:text-neutral-400 line-clamp-3 leading-relaxed">
+              {/* 用户推荐语优先展示，没有则展示 OG description */}
+              {link.recommendation ?? link.ogDescription}
+            </p>
+          )}
+
+          {/* 分类 badge + 失效标记 */}
+          <div className="flex items-center gap-2 flex-wrap mt-auto pt-2">
+            {link.category && (
+              <Badge
+                variant="outline"
+                className="font-mono text-[9px] uppercase tracking-widest rounded-none border-[var(--foreground)]/40 text-neutral-500"
+              >
+                {categoryLabel}
+              </Badge>
+            )}
+            {link.status === "ARCHIVED" && (
+              <Badge
+                variant="outline"
+                className="font-mono text-[9px] uppercase tracking-widest rounded-none border-[#CC0000]/60 text-[#CC0000]"
+              >
+                {t("archivedBadge")}
+              </Badge>
+            )}
+          </div>
+
+          {/* 提交人 + host 来源 */}
+          <div className="flex items-center justify-between text-[10px] font-mono text-neutral-400 pt-1">
+            <span className="truncate max-w-[60%]">{link.host}</span>
+          </div>
+        </div>
+      </a>
+
+      {/* 举报区：与整卡点击分离（ReportButton 内部阻止冒泡） */}
+      <div className="px-4 pb-3 border-t border-[var(--foreground)]/10 pt-2 flex justify-end">
+        <ReportButton linkId={link.id} isLoggedIn={isLoggedIn} />
+      </div>
+    </li>
+  );
+}

--- a/app/feed/components/ReportButton.tsx
+++ b/app/feed/components/ReportButton.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+/**
+ * 举报按钮 + 举报 Dialog 组件。
+ * - 未登录：点击时 toast 提示需要登录
+ * - 已登录：弹出 Dialog，填写可选原因后提交 POST /api/community/links/{id}/report
+ * 参照 Contribute.tsx 的 Dialog 模式实现。
+ */
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Flag } from "lucide-react";
+
+interface ReportButtonProps {
+  /** 被举报的链接 ID */
+  linkId: number;
+  /** 当前用户是否已登录（由父组件/页面传入，避免在每张卡片都重新请求 session） */
+  isLoggedIn: boolean;
+}
+
+export function ReportButton({ linkId, isLoggedIn }: ReportButtonProps) {
+  const t = useTranslations("feed.report");
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false); // 举报成功后隐藏按钮
+
+  /**
+   * 未登录时点击举报，弹浏览器原生 alert（轻量，避免引入额外 toast provider 依赖）。
+   * 后续如果需要引导跳登录页，可改成 router.push。
+   */
+  function handleUnauth(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation(); // 阻止冒泡，不触发整卡链接跳转
+    alert(t("loginRequired"));
+  }
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/community/links/${linkId}/report`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason: reason.trim() || undefined }),
+      });
+      if (res.ok) {
+        setDone(true);
+        setOpen(false);
+        // 举报成功后短暂显示反馈——用 alert 保持轻量；后续可改 sonner toast
+        alert(t("successToast"));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // 已举报成功，不再显示按钮
+  if (done) return null;
+
+  // 未登录：直接用普通按钮，点击触发提示
+  if (!isLoggedIn) {
+    return (
+      <button
+        onClick={handleUnauth}
+        className="flex items-center gap-1 text-[10px] font-mono uppercase tracking-widest text-neutral-400 hover:text-[#CC0000] transition-colors"
+        aria-label={t("submitButton")}
+      >
+        <Flag className="h-3 w-3" />
+        {t("submitButton")}
+      </button>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          // 阻止事件冒泡，避免触发整卡的 <a> 跳原文
+          onClick={(e) => e.stopPropagation()}
+          className="flex items-center gap-1 text-[10px] font-mono uppercase tracking-widest text-neutral-400 hover:text-[#CC0000] transition-colors"
+          aria-label={t("submitButton")}
+        >
+          <Flag className="h-3 w-3" />
+          {t("submitButton")}
+        </button>
+      </DialogTrigger>
+
+      <DialogContent
+        className="sm:max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DialogHeader>
+          <DialogTitle>{t("title")}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium">{t("reasonLabel")}</label>
+          <textarea
+            className="w-full border border-[var(--foreground)]/30 rounded-none p-2 text-sm resize-none h-24 focus:outline-none focus:border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)]"
+            placeholder={t("reasonPlaceholder")}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            maxLength={200}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="rounded-none"
+          >
+            {t("submitButton")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,0 +1,161 @@
+/**
+ * /feed 社区分享墙列表页。
+ *
+ * SSR 直连后端拉已审核通过（APPROVED）的链接，revalidate: 120 减少 DB 压力。
+ * 分类过滤通过 URL searchParam ?category=<slug> 实现，SSR 可直接读取。
+ *
+ * 登录态检测：由于认证走 localStorage（client-only），isLoggedIn 无法在 SSR 层知道，
+ * 故 LinkCard 中的举报按钮默认以未登录态渲染，由 ReportButton 内部在 client 端
+ * 补充真实登录判断。这里通过 FeedAuthWrapper 传递 client 端的 isLoggedIn 状态。
+ */
+
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { Header } from "@/app/components/Header";
+import { Footer } from "@/app/components/Footer";
+import { Suspense } from "react";
+import { CategoryTabs } from "@/app/feed/components/CategoryTabs";
+import { FeedAuthWrapper } from "@/app/feed/components/FeedAuthWrapper";
+import type { SharedLinkView, CategorySlug } from "@/app/feed/types";
+import type { ApiResponse } from "@/app/feed/types";
+import Link from "next/link";
+
+export const revalidate = 120;
+
+export const metadata: Metadata = {
+  title: "社区分享墙 · Involution Hell",
+  description: "群友精选好文，随手转发，沉淀有价值的信息流。",
+};
+
+/**
+ * 从后端拉取 APPROVED 的链接列表。
+ * category 为空时拉全部，否则按 slug 过滤。
+ */
+async function fetchLinks(category?: string): Promise<SharedLinkView[]> {
+  const backendUrl = process.env.BACKEND_URL;
+  if (!backendUrl) {
+    // 配置缺失时给清晰错误，而非静默空列表
+    throw new Error("BACKEND_URL is not configured");
+  }
+
+  // 构造查询参数
+  const params = new URLSearchParams({ limit: "50", offset: "0" });
+  if (category) params.set("category", category);
+
+  const res = await fetch(
+    `${backendUrl}/api/community/links?${params.toString()}`,
+    {
+      next: { revalidate: 120 },
+      headers: {
+        accept: "application/json",
+        "user-agent": "InvolutionHell-SSR/1.0 (+https://involutionhell.com)",
+      },
+    },
+  );
+
+  if (!res.ok) {
+    // 后端 5xx / 网络错误才抛，前端会走 error.tsx（如果有的话）
+    throw new Error(
+      `/api/community/links backend ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const json = (await res.json()) as ApiResponse<SharedLinkView[]>;
+  return json.success && json.data ? json.data : [];
+}
+
+interface FeedPageProps {
+  searchParams: Promise<{ category?: string }>;
+}
+
+export default async function FeedPage({ searchParams }: FeedPageProps) {
+  const t = await getTranslations("feed");
+  const tCategory = await getTranslations("feed.category");
+
+  // Next.js 15+ searchParams 是 Promise，需要 await
+  const resolvedParams = await searchParams;
+  const category = resolvedParams.category ?? "";
+
+  // 获取链接列表，出错时降级为空数组（不让整页崩溃）
+  let links: SharedLinkView[] = [];
+  try {
+    links = await fetchLinks(category || undefined);
+  } catch (err) {
+    // SSR 拉取失败时记录日志，降级展示空状态，不崩溃整页
+    console.error("[feed/page] fetchLinks failed:", err);
+  }
+
+  /**
+   * 预计算每条链接的分类显示名（i18n）。
+   * 在 server 端翻译，避免 LinkCard（server component）里调 useTranslations（client hook）。
+   */
+  function getCategoryLabel(slug: CategorySlug | null): string {
+    if (!slug) return "";
+    try {
+      return tCategory(slug);
+    } catch {
+      return slug;
+    }
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
+        <div className="max-w-6xl mx-auto px-6 lg:px-8">
+          {/* 页面头部，风格对齐 /events */}
+          <header className="border-t-4 border-[var(--foreground)] pt-6 mb-10">
+            <div className="font-mono text-[10px] uppercase tracking-[0.3em] text-neutral-500">
+              Community · Feed
+            </div>
+            <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mt-2">
+              <div>
+                <h1 className="font-serif text-4xl md:text-5xl font-black uppercase tracking-tight text-[var(--foreground)]">
+                  {t("title")}
+                </h1>
+                <p className="mt-3 text-sm md:text-base text-neutral-600 dark:text-neutral-400 max-w-2xl leading-relaxed">
+                  {t("subtitle")}
+                </p>
+              </div>
+              {/* 提交按钮 */}
+              <Link
+                href="/feed/submit"
+                className="shrink-0 inline-block px-6 py-2.5 border border-[var(--foreground)] font-sans text-xs uppercase tracking-widest font-bold text-[var(--foreground)] hover:bg-[var(--foreground)] hover:text-[var(--background)] transition-all duration-200"
+              >
+                + 丢个链接
+              </Link>
+            </div>
+          </header>
+
+          {/* 分类 tab（client component，依赖 router/searchParams） */}
+          <div className="mb-8">
+            {/* Suspense 包裹是因为 CategoryTabs 内部调用 useSearchParams，
+                Next.js 要求 useSearchParams 的父级有 Suspense 边界 */}
+            <Suspense
+              fallback={
+                <div className="h-8 animate-pulse bg-neutral-100 dark:bg-neutral-900 rounded" />
+              }
+            >
+              <CategoryTabs />
+            </Suspense>
+          </div>
+
+          {/* 链接卡片瀑布流 */}
+          {links.length === 0 ? (
+            // 空状态提示
+            <div className="border border-dashed border-[var(--foreground)]/40 p-10 text-center text-neutral-500 font-sans text-sm leading-relaxed">
+              {t("empty")}
+            </div>
+          ) : (
+            // FeedAuthWrapper 是 client 组件，负责读取登录态后注入到 LinkCard
+            <FeedAuthWrapper
+              links={links}
+              getCategoryLabel={getCategoryLabel}
+            />
+          )}
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/feed/submit/layout.tsx
+++ b/app/feed/submit/layout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import { Header } from "@/app/components/Header";
+import { Footer } from "@/app/components/Footer";
+
+/**
+ * /feed/submit 的 Server Component layout。
+ *
+ * 把 Header / Footer（依赖 next-intl/server.getTranslations 的 async Server Component）
+ * 放在这一层，让子 page 可以保持 "use client"，不再触发
+ * "async Client Component is not supported" 报错。
+ */
+export default function SubmitLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Header />
+      {children}
+      <Footer />
+    </>
+  );
+}

--- a/app/feed/submit/page.tsx
+++ b/app/feed/submit/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+/**
+ * /feed/submit 提交页。
+ *
+ * - 需要登录：未登录自动跳 /login?next=/feed/submit
+ * - 表单：URL（必填）+ 推荐语 textarea（选填，max 200 字）
+ * - 提交成功 toast 后跳转 /u/[userId]/shares（M8 负责实现，当前可能 404，可接受）
+ */
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useAuth } from "@/lib/use-auth";
+import { Header } from "@/app/components/Header";
+import { Footer } from "@/app/components/Footer";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export default function SubmitPage() {
+  const t = useTranslations("feed.submit");
+  const { user, status } = useAuth();
+  const router = useRouter();
+
+  const [url, setUrl] = useState("");
+  const [recommendation, setRecommendation] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * 登录态守卫：认证状态确认为未登录时跳登录页。
+   * status === "loading" 阶段不跳，避免误判（localStorage 读取有延迟）。
+   */
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.replace("/login?next=/feed/submit");
+    }
+  }, [status, router]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!url.trim()) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      // satoken 从 localStorage 读取，随请求头发送（与其他需鉴权的接口一致）
+      const token =
+        typeof window !== "undefined" ? localStorage.getItem("satoken") : null;
+
+      const res = await fetch("/api/community/links", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { satoken: token } : {}),
+        },
+        body: JSON.stringify({
+          url: url.trim(),
+          recommendation: recommendation.trim() || undefined,
+        }),
+      });
+
+      if (res.ok) {
+        // 提交成功：toast 反馈 + 跳用户分享列表页
+        // 使用 alert 保持轻量（与 ReportButton 一致，无额外 toast provider 依赖）
+        alert(t("successToast"));
+        if (user?.id) {
+          router.push(`/u/${user.id}/shares`);
+        } else {
+          router.push("/feed");
+        }
+      } else {
+        // 解析后端错误消息
+        const body = await res.json().catch(() => ({}));
+        setError(
+          (body as { message?: string }).message ??
+            `提交失败（HTTP ${res.status}）`,
+        );
+      }
+    } catch {
+      setError("网络错误，请稍后重试");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // 认证加载中：渲染骨架避免布局跳动
+  if (status === "loading") {
+    return (
+      <>
+        <Header />
+        <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
+          <div className="max-w-xl mx-auto px-6 lg:px-8 animate-pulse">
+            <div className="h-8 bg-neutral-100 dark:bg-neutral-900 rounded mb-4" />
+            <div className="h-4 bg-neutral-100 dark:bg-neutral-900 rounded w-2/3" />
+          </div>
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  // 未登录：等待 useEffect 跳转（渲染空内容避免闪烁）
+  if (status === "unauthenticated") {
+    return null;
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
+        <div className="max-w-xl mx-auto px-6 lg:px-8">
+          {/* 页头 */}
+          <header className="border-t-4 border-[var(--foreground)] pt-6 mb-10">
+            <div className="font-mono text-[10px] uppercase tracking-[0.3em] text-neutral-500">
+              Community · Feed · Submit
+            </div>
+            <h1 className="font-serif text-4xl md:text-5xl font-black uppercase mt-2 tracking-tight text-[var(--foreground)]">
+              {t("title")}
+            </h1>
+          </header>
+
+          {/* 提交表单 */}
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* URL 输入 */}
+            <div className="space-y-2">
+              <Label
+                htmlFor="url"
+                className="font-mono text-xs uppercase tracking-widest"
+              >
+                {t("urlLabel")}
+              </Label>
+              <Input
+                id="url"
+                type="url"
+                placeholder={t("urlPlaceholder")}
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                required
+                className="rounded-none border-[var(--foreground)] focus-visible:ring-0 focus-visible:border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)]"
+              />
+            </div>
+
+            {/* 推荐语 textarea */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label
+                  htmlFor="recommendation"
+                  className="font-mono text-xs uppercase tracking-widest"
+                >
+                  {t("recommendationLabel")}
+                </Label>
+                {/* 字数计数 */}
+                <span className="font-mono text-[10px] text-neutral-400">
+                  {t("charCount", { count: recommendation.length })}
+                </span>
+              </div>
+              <textarea
+                id="recommendation"
+                className="w-full border border-[var(--foreground)] p-3 text-sm resize-none h-28 focus:outline-none focus:border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)] placeholder:text-neutral-400"
+                placeholder={t("recommendationPlaceholder")}
+                value={recommendation}
+                onChange={(e) => {
+                  // 限制最多 200 字
+                  if (e.target.value.length <= 200) {
+                    setRecommendation(e.target.value);
+                  }
+                }}
+                maxLength={200}
+              />
+            </div>
+
+            {/* 错误提示 */}
+            {error && (
+              <p className="text-sm text-[#CC0000] font-mono">{error}</p>
+            )}
+
+            {/* 提交按钮 */}
+            <div className="flex items-center gap-4">
+              <Button
+                type="submit"
+                disabled={submitting || !url.trim()}
+                className="rounded-none px-8 py-3 font-sans text-xs uppercase tracking-widest font-bold bg-[var(--foreground)] text-[var(--background)] hover:bg-[var(--background)] hover:text-[var(--foreground)] border border-[var(--foreground)] transition-all duration-200 h-auto disabled:opacity-40"
+              >
+                {submitting ? t("submitting") : t("submitButton")}
+              </Button>
+              <button
+                type="button"
+                onClick={() => router.back()}
+                className="font-mono text-xs uppercase tracking-widest text-neutral-500 hover:text-[var(--foreground)] transition-colors"
+              >
+                取消
+              </button>
+            </div>
+          </form>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/feed/submit/page.tsx
+++ b/app/feed/submit/page.tsx
@@ -12,8 +12,6 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useAuth } from "@/lib/use-auth";
-import { Header } from "@/app/components/Header";
-import { Footer } from "@/app/components/Footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -44,6 +42,10 @@ export default function SubmitPage() {
     setSubmitting(true);
     setError(null);
 
+    // 15s 超时保护，避免 fetch 永远 hang 卡在 "提交中..."
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 15_000);
+
     try {
       // satoken 从 localStorage 读取，随请求头发送（与其他需鉴权的接口一致）
       const token =
@@ -59,14 +61,16 @@ export default function SubmitPage() {
           url: url.trim(),
           recommendation: recommendation.trim() || undefined,
         }),
+        signal: ctrl.signal,
       });
 
       if (res.ok) {
         // 提交成功：toast 反馈 + 跳用户分享列表页
         // 使用 alert 保持轻量（与 ReportButton 一致，无额外 toast provider 依赖）
         alert(t("successToast"));
-        if (user?.id) {
-          router.push(`/u/${user.id}/shares`);
+        // 路由 param 是 [username] 不是 id，必须用 user.username 而不是 user.id
+        if (user?.username) {
+          router.push(`/u/${user.username}/shares`);
         } else {
           router.push("/feed");
         }
@@ -78,9 +82,14 @@ export default function SubmitPage() {
             `提交失败（HTTP ${res.status}）`,
         );
       }
-    } catch {
-      setError("网络错误，请稍后重试");
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") {
+        setError("请求超时（15 秒未响应），请稍后重试");
+      } else {
+        setError("网络错误，请稍后重试");
+      }
     } finally {
+      clearTimeout(timer);
       setSubmitting(false);
     }
   }
@@ -88,16 +97,12 @@ export default function SubmitPage() {
   // 认证加载中：渲染骨架避免布局跳动
   if (status === "loading") {
     return (
-      <>
-        <Header />
-        <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
-          <div className="max-w-xl mx-auto px-6 lg:px-8 animate-pulse">
-            <div className="h-8 bg-neutral-100 dark:bg-neutral-900 rounded mb-4" />
-            <div className="h-4 bg-neutral-100 dark:bg-neutral-900 rounded w-2/3" />
-          </div>
-        </main>
-        <Footer />
-      </>
+      <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
+        <div className="max-w-xl mx-auto px-6 lg:px-8 animate-pulse">
+          <div className="h-8 bg-neutral-100 dark:bg-neutral-900 rounded mb-4" />
+          <div className="h-4 bg-neutral-100 dark:bg-neutral-900 rounded w-2/3" />
+        </div>
+      </main>
     );
   }
 
@@ -107,96 +112,90 @@ export default function SubmitPage() {
   }
 
   return (
-    <>
-      <Header />
-      <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
-        <div className="max-w-xl mx-auto px-6 lg:px-8">
-          {/* 页头 */}
-          <header className="border-t-4 border-[var(--foreground)] pt-6 mb-10">
-            <div className="font-mono text-[10px] uppercase tracking-[0.3em] text-neutral-500">
-              Community · Feed · Submit
-            </div>
-            <h1 className="font-serif text-4xl md:text-5xl font-black uppercase mt-2 tracking-tight text-[var(--foreground)]">
-              {t("title")}
-            </h1>
-          </header>
+    <main className="pt-32 pb-16 bg-[var(--background)] min-h-screen">
+      <div className="max-w-xl mx-auto px-6 lg:px-8">
+        {/* 页头 */}
+        <header className="border-t-4 border-[var(--foreground)] pt-6 mb-10">
+          <div className="font-mono text-[10px] uppercase tracking-[0.3em] text-neutral-500">
+            Community · Feed · Submit
+          </div>
+          <h1 className="font-serif text-4xl md:text-5xl font-black uppercase mt-2 tracking-tight text-[var(--foreground)]">
+            {t("title")}
+          </h1>
+        </header>
 
-          {/* 提交表单 */}
-          <form onSubmit={handleSubmit} className="space-y-6">
-            {/* URL 输入 */}
-            <div className="space-y-2">
+        {/* 提交表单 */}
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* URL 输入 */}
+          <div className="space-y-2">
+            <Label
+              htmlFor="url"
+              className="font-mono text-xs uppercase tracking-widest"
+            >
+              {t("urlLabel")}
+            </Label>
+            <Input
+              id="url"
+              type="url"
+              placeholder={t("urlPlaceholder")}
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              required
+              className="rounded-none border-[var(--foreground)] focus-visible:ring-0 focus-visible:border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)]"
+            />
+          </div>
+
+          {/* 推荐语 textarea */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
               <Label
-                htmlFor="url"
+                htmlFor="recommendation"
                 className="font-mono text-xs uppercase tracking-widest"
               >
-                {t("urlLabel")}
+                {t("recommendationLabel")}
               </Label>
-              <Input
-                id="url"
-                type="url"
-                placeholder={t("urlPlaceholder")}
-                value={url}
-                onChange={(e) => setUrl(e.target.value)}
-                required
-                className="rounded-none border-[var(--foreground)] focus-visible:ring-0 focus-visible:border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)]"
-              />
+              {/* 字数计数 */}
+              <span className="font-mono text-[10px] text-neutral-400">
+                {t("charCount", { count: recommendation.length })}
+              </span>
             </div>
+            <textarea
+              id="recommendation"
+              className="w-full border border-[var(--foreground)] p-3 text-sm resize-none h-28 focus:outline-none focus:border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)] placeholder:text-neutral-400"
+              placeholder={t("recommendationPlaceholder")}
+              value={recommendation}
+              onChange={(e) => {
+                // 限制最多 200 字
+                if (e.target.value.length <= 200) {
+                  setRecommendation(e.target.value);
+                }
+              }}
+              maxLength={200}
+            />
+          </div>
 
-            {/* 推荐语 textarea */}
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label
-                  htmlFor="recommendation"
-                  className="font-mono text-xs uppercase tracking-widest"
-                >
-                  {t("recommendationLabel")}
-                </Label>
-                {/* 字数计数 */}
-                <span className="font-mono text-[10px] text-neutral-400">
-                  {t("charCount", { count: recommendation.length })}
-                </span>
-              </div>
-              <textarea
-                id="recommendation"
-                className="w-full border border-[var(--foreground)] p-3 text-sm resize-none h-28 focus:outline-none focus:border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)] placeholder:text-neutral-400"
-                placeholder={t("recommendationPlaceholder")}
-                value={recommendation}
-                onChange={(e) => {
-                  // 限制最多 200 字
-                  if (e.target.value.length <= 200) {
-                    setRecommendation(e.target.value);
-                  }
-                }}
-                maxLength={200}
-              />
-            </div>
+          {/* 错误提示 */}
+          {error && <p className="text-sm text-[#CC0000] font-mono">{error}</p>}
 
-            {/* 错误提示 */}
-            {error && (
-              <p className="text-sm text-[#CC0000] font-mono">{error}</p>
-            )}
-
-            {/* 提交按钮 */}
-            <div className="flex items-center gap-4">
-              <Button
-                type="submit"
-                disabled={submitting || !url.trim()}
-                className="rounded-none px-8 py-3 font-sans text-xs uppercase tracking-widest font-bold bg-[var(--foreground)] text-[var(--background)] hover:bg-[var(--background)] hover:text-[var(--foreground)] border border-[var(--foreground)] transition-all duration-200 h-auto disabled:opacity-40"
-              >
-                {submitting ? t("submitting") : t("submitButton")}
-              </Button>
-              <button
-                type="button"
-                onClick={() => router.back()}
-                className="font-mono text-xs uppercase tracking-widest text-neutral-500 hover:text-[var(--foreground)] transition-colors"
-              >
-                取消
-              </button>
-            </div>
-          </form>
-        </div>
-      </main>
-      <Footer />
-    </>
+          {/* 提交按钮 */}
+          <div className="flex items-center gap-4">
+            <Button
+              type="submit"
+              disabled={submitting || !url.trim()}
+              className="rounded-none px-8 py-3 font-sans text-xs uppercase tracking-widest font-bold bg-[var(--foreground)] text-[var(--background)] hover:bg-[var(--background)] hover:text-[var(--foreground)] border border-[var(--foreground)] transition-all duration-200 h-auto disabled:opacity-40"
+            >
+              {submitting ? t("submitting") : t("submitButton")}
+            </Button>
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="font-mono text-xs uppercase tracking-widest text-neutral-500 hover:text-[var(--foreground)] transition-colors"
+            >
+              取消
+            </button>
+          </div>
+        </form>
+      </div>
+    </main>
   );
 }

--- a/app/feed/types.ts
+++ b/app/feed/types.ts
@@ -1,0 +1,59 @@
+/**
+ * 社区分享链接相关类型定义。
+ * 与后端 SharedLinkView.java 字段一一对应。
+ */
+
+/** 分类 slug 枚举（与后端保持一致） */
+export type CategorySlug =
+  | "ai_frontier"
+  | "engineering"
+  | "job"
+  | "grad_study"
+  | "industry"
+  | "learning"
+  | "lifestyle"
+  | "other";
+
+/** 所有可用分类 slug 列表，用于 UI 渲染分类 tab */
+export const CATEGORY_SLUGS: CategorySlug[] = [
+  "ai_frontier",
+  "engineering",
+  "job",
+  "grad_study",
+  "industry",
+  "learning",
+  "lifestyle",
+  "other",
+];
+
+/** 后端 SharedLinkView 对应的前端视图类型 */
+export interface SharedLinkView {
+  id: number;
+  submitterId: number;
+  url: string;
+  host: string;
+  recommendation: string | null;
+  ogTitle: string | null;
+  ogDescription: string | null;
+  ogCover: string | null;
+  ogSiteName: string | null;
+  ogFetchFailed: boolean;
+  category: CategorySlug | null;
+  status:
+    | "PENDING"
+    | "APPROVED"
+    | "PENDING_MANUAL"
+    | "FLAGGED"
+    | "REJECTED"
+    | "ARCHIVED";
+  reportCount: number;
+  archivedAt: string | null;
+  createdAt: string;
+}
+
+/** 后端通用响应包装格式 */
+export interface ApiResponse<T> {
+  success: boolean;
+  message?: string;
+  data?: T;
+}

--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+/**
+ * /share — 极简快速分享入口。
+ *
+ * 设计目标：
+ *   - **短路径**：方便口头传播（"去 involutionhell.com/share 丢链接"）
+ *   - **极简 UI**：无 Header / Footer，单页居中卡片 + 一个 URL 输入 + 一个按钮
+ *   - **支持预填**：`/share?url=<外站 URL>&text=<推荐语>`，配合浏览器书签脚本（bookmarklet）
+ *     或微信分享菜单跳转使用
+ *   - **成功后停留不跳**：展示"再来一条 / 看看大家分享了啥"两个入口
+ *
+ * 典型使用姿势：
+ *   1. 群里发 "好文章丢这里 → involutionhell.com/share?url=https%3A%2F%2Fmp.weixin.qq.com%2F..."
+ *   2. 浏览器书签栏添加：
+ *      javascript:location.href='https://involutionhell.com/share?url='+encodeURIComponent(location.href)
+ *      任何网页一点书签跳过来预填。
+ *
+ * 与 /feed/submit 的区别：后者是完整站点布局下的提交页；本页去除了所有导航，
+ * 专门给"点击即分享"场景用。两者调同一个后端 POST /api/community/links。
+ */
+
+import { useEffect, useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useAuth } from "@/lib/use-auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Link2, CheckCircle2 } from "lucide-react";
+
+// 内层组件：读 searchParams 需要 Suspense 边界（Next 15+ 要求）
+function ShareInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { user, status } = useAuth();
+
+  // 从 URL 预填：?url=... / ?text=...（decodeURIComponent 由 URL 构造器负责）
+  const prefillUrl = searchParams.get("url") ?? "";
+  const prefillText = searchParams.get("text") ?? "";
+
+  const [url, setUrl] = useState(prefillUrl);
+  const [recommendation, setRecommendation] = useState(prefillText);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // 成功后停留在本页展示感谢卡片，而非跳走——方便连续分享
+  const [succeeded, setSucceeded] = useState(false);
+
+  // 未登录：带 next 跳登录，回跳后保留原始 url/text query 以免用户重新粘贴
+  useEffect(() => {
+    if (status !== "unauthenticated") return;
+    const currentQs = new URLSearchParams();
+    if (prefillUrl) currentQs.set("url", prefillUrl);
+    if (prefillText) currentQs.set("text", prefillText);
+    const back = `/share${currentQs.toString() ? "?" + currentQs.toString() : ""}`;
+    router.replace(`/login?next=${encodeURIComponent(back)}`);
+  }, [status, router, prefillUrl, prefillText]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!url.trim()) return;
+    setSubmitting(true);
+    setError(null);
+
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 15_000);
+
+    try {
+      const token =
+        typeof window !== "undefined" ? localStorage.getItem("satoken") : null;
+
+      const res = await fetch("/api/community/links", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { satoken: token } : {}),
+        },
+        body: JSON.stringify({
+          url: url.trim(),
+          recommendation: recommendation.trim() || undefined,
+        }),
+        signal: ctrl.signal,
+      });
+
+      if (res.ok) {
+        setSucceeded(true);
+        setUrl("");
+        setRecommendation("");
+      } else {
+        const body = await res.json().catch(() => ({}));
+        setError(
+          (body as { message?: string }).message ??
+            `提交失败（HTTP ${res.status}）`,
+        );
+      }
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") {
+        setError("请求超时（15 秒未响应），请稍后重试");
+      } else {
+        setError("网络错误，请稍后重试");
+      }
+    } finally {
+      clearTimeout(timer);
+      setSubmitting(false);
+    }
+  }
+
+  // 认证加载中：骨架占位
+  if (status === "loading") {
+    return (
+      <div className="animate-pulse space-y-4">
+        <div className="h-8 bg-neutral-100 dark:bg-neutral-900 rounded" />
+        <div className="h-12 bg-neutral-100 dark:bg-neutral-900 rounded" />
+        <div className="h-24 bg-neutral-100 dark:bg-neutral-900 rounded" />
+      </div>
+    );
+  }
+
+  // 未登录：等待 effect 跳转，不渲染内容
+  if (status === "unauthenticated") return null;
+
+  // 成功卡片：突出"再来一条"，让连续分享 1 次点击完成
+  if (succeeded) {
+    return (
+      <div className="space-y-6 text-center">
+        <CheckCircle2
+          className="mx-auto h-16 w-16 text-emerald-600"
+          strokeWidth={1.5}
+        />
+        <div>
+          <h2 className="font-serif text-3xl font-black uppercase tracking-tight">
+            已丢进漩涡
+          </h2>
+          <p className="mt-2 text-sm text-neutral-500">
+            AI 正在审核分类，通过后会出现在社区分享墙。
+          </p>
+        </div>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+          <Button
+            type="button"
+            onClick={() => {
+              setSucceeded(false);
+              setError(null);
+            }}
+            className="rounded-none bg-[var(--foreground)] text-[var(--background)] hover:bg-[var(--background)] hover:text-[var(--foreground)] border border-[var(--foreground)] font-mono uppercase tracking-widest"
+          >
+            再来一条
+          </Button>
+          <Link
+            href="/feed"
+            className="inline-flex items-center justify-center px-6 py-2 rounded-none border border-[var(--foreground)] font-mono uppercase tracking-widest text-xs hover:bg-[var(--foreground)] hover:text-[var(--background)] transition-colors"
+          >
+            去看看大家分享了啥 →
+          </Link>
+          {user?.username && (
+            <Link
+              href={`/u/${user.username}/shares`}
+              className="inline-flex items-center justify-center px-6 py-2 rounded-none font-mono uppercase tracking-widest text-xs text-neutral-500 hover:text-[var(--foreground)]"
+            >
+              我的分享
+            </Link>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // 主表单
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="text-center space-y-2">
+        <div className="font-mono text-[10px] uppercase tracking-[0.3em] text-neutral-500">
+          Involution Hell · Quick Share
+        </div>
+        <h1 className="font-serif text-3xl md:text-4xl font-black uppercase tracking-tight inline-flex items-center gap-3">
+          <Link2 className="h-7 w-7" strokeWidth={2.5} />
+          丢个链接
+        </h1>
+        <p className="text-xs text-neutral-500">
+          粘 URL + 一句话推荐，AI 会审核并分类到社区分享墙。
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <label className="font-mono text-[10px] uppercase tracking-widest text-neutral-500">
+          文章链接
+        </label>
+        <Input
+          type="url"
+          required
+          autoFocus
+          placeholder="https://mp.weixin.qq.com/s/..."
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="rounded-none border-[var(--foreground)] font-mono text-sm"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="font-mono text-[10px] uppercase tracking-widest text-neutral-500">
+          一句话推荐（选填，≤200 字）
+        </label>
+        <textarea
+          placeholder="为什么推荐这篇？"
+          value={recommendation}
+          onChange={(e) => {
+            if (e.target.value.length <= 200) setRecommendation(e.target.value);
+          }}
+          maxLength={200}
+          rows={3}
+          className="w-full rounded-none border border-[var(--foreground)] bg-transparent px-3 py-2 text-sm font-sans focus:outline-none focus:ring-1 focus:ring-[var(--foreground)]"
+        />
+      </div>
+
+      {error && (
+        <p className="text-sm text-[#CC0000] font-mono text-center">{error}</p>
+      )}
+
+      <Button
+        type="submit"
+        disabled={submitting || !url.trim()}
+        className="w-full h-14 rounded-none bg-[var(--foreground)] text-[var(--background)] hover:bg-[var(--background)] hover:text-[var(--foreground)] border border-[var(--foreground)] font-serif text-lg uppercase italic tracking-tighter disabled:opacity-40"
+      >
+        {submitting ? "提交中..." : "分享"}
+      </Button>
+
+      <div className="text-center">
+        <Link
+          href="/feed"
+          className="font-mono text-[10px] uppercase tracking-widest text-neutral-500 hover:text-[var(--foreground)]"
+        >
+          跳过，去看看大家分享了啥 →
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+export default function SharePage() {
+  // 全屏居中卡片；刻意不套 Header / Footer，保持"一屏点击即用"
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6 bg-[var(--background)]">
+      <div className="w-full max-w-md border border-[var(--foreground)] p-6 md:p-10 bg-[var(--background)]">
+        <Suspense
+          fallback={
+            <div className="h-8 bg-neutral-100 dark:bg-neutral-900 animate-pulse rounded" />
+          }
+        >
+          <ShareInner />
+        </Suspense>
+      </div>
+    </main>
+  );
+}

--- a/app/u/[username]/SharesLinkIfOwner.tsx
+++ b/app/u/[username]/SharesLinkIfOwner.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { useAuth } from "@/lib/use-auth";
+
+interface Props {
+  /** 当前页面主人的 GitHub 数字 ID（可能为 null 的老数据） */
+  ownerGithubId: number | null;
+  /** 当前页面主人的系统 username，形如 "github_114939201" */
+  ownerUsername: string;
+  /** URL 上的标识符（/u/<identifier>），shares 页 route 用相同 identifier */
+  identifier: string;
+}
+
+/**
+ * 个人主页"我的分享"入口。
+ *
+ * 只在"本人访问自己主页"时渲染——其他用户访问时不展示，
+ * 避免暴露非本人看不到内容的死链（shares 页面本身也会做二次校验）。
+ *
+ * 判定逻辑照搬 EditLinkIfOwner：优先 githubId 匹配，退回 username。
+ */
+export function SharesLinkIfOwner({
+  ownerGithubId,
+  ownerUsername,
+  identifier,
+}: Props) {
+  const { user, status } = useAuth();
+  if (status !== "authenticated" || !user) return null;
+
+  const isOwner =
+    (ownerGithubId != null && user.githubId === ownerGithubId) ||
+    user.username === ownerUsername;
+  if (!isOwner) return null;
+
+  return (
+    <Link
+      href={`/u/${identifier}/shares`}
+      className="font-mono text-[11px] uppercase tracking-widest hover:text-[#CC0000] transition-colors flex items-center gap-1 font-bold"
+      data-umami-event="profile_shares_click"
+    >
+      我的分享
+    </Link>
+  );
+}

--- a/app/u/[username]/SharesOnProfile.tsx
+++ b/app/u/[username]/SharesOnProfile.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+/**
+ * 个人主页"我的分享"嵌入式区块。
+ *
+ * 出现位置：profile 页原来的 GitHub repos + 文档贡献两块（已删）位置。
+ *
+ * 可见规则（v1）：
+ * - 仅本人访问自己主页时渲染
+ * - 非本人：返回 null，保持页面简洁，不展示空占位
+ *
+ * 数据源：GET /api/community/links/mine（需登录）
+ *   - 包含本人全状态的分享（PENDING / APPROVED / FLAGGED / ARCHIVED…）
+ *   - 列表默认展示最近 6 条，带状态 badge；底部"查看全部"跳 /u/{identifier}/shares
+ *
+ * 后端公开 API 还没做（/api/community/users/{id}/shares），所以无法展示"别人的分享"。
+ * 等真需要公开展示时再开那个接口，本组件 props 不变。
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useAuth } from "@/lib/use-auth";
+import type { ApiResponse, SharedLinkView } from "@/app/feed/types";
+
+interface Props {
+  /** 当前页面主人的 GitHub 数字 ID（可能为 null 的老数据） */
+  ownerGithubId: number | null;
+  /** 当前页面主人的系统 username，形如 "github_114939201" */
+  ownerUsername: string;
+  /** URL 上的标识符（用于拼 /u/{identifier}/shares 跳转） */
+  identifier: string;
+}
+
+const STATUS_BADGE: Record<
+  SharedLinkView["status"],
+  { label: string; className: string }
+> = {
+  PENDING: { label: "审核中", className: "bg-amber-100 text-amber-900" },
+  APPROVED: { label: "已通过", className: "bg-emerald-100 text-emerald-900" },
+  PENDING_MANUAL: {
+    label: "人工待审",
+    className: "bg-orange-100 text-orange-900",
+  },
+  FLAGGED: { label: "需要复核", className: "bg-red-100 text-red-900" },
+  REJECTED: { label: "已拒绝", className: "bg-zinc-200 text-zinc-700" },
+  ARCHIVED: { label: "原文失效", className: "bg-zinc-100 text-zinc-600" },
+};
+
+export function SharesOnProfile({
+  ownerGithubId,
+  ownerUsername,
+  identifier,
+}: Props) {
+  const { user, status } = useAuth();
+  const [links, setLinks] = useState<SharedLinkView[] | null>(null);
+
+  const isOwner = useMemo(() => {
+    if (status !== "authenticated" || !user) return false;
+    if (ownerGithubId != null && user.githubId === ownerGithubId) return true;
+    return user.username === ownerUsername;
+  }, [status, user, ownerGithubId, ownerUsername]);
+
+  useEffect(() => {
+    if (!isOwner) return;
+    let aborted = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/community/links/mine", {
+          cache: "no-store",
+        });
+        if (!res.ok) return;
+        const body = (await res.json()) as ApiResponse<SharedLinkView[]>;
+        if (!aborted && body.success && body.data) setLinks(body.data);
+      } catch {
+        // 静默失败：个人主页上的次级栏目不值得打扰用户
+      }
+    })();
+    return () => {
+      aborted = true;
+    };
+  }, [isOwner]);
+
+  // 非本人：完全不渲染，避免展示空占位
+  if (!isOwner) return null;
+
+  return (
+    <section className="h-full border border-[var(--foreground)] p-6 lg:p-8 flex flex-col gap-4">
+      <div className="flex items-baseline justify-between gap-3 flex-wrap border-b border-[var(--foreground)] pb-3">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-widest text-neutral-500">
+            Community · Feed
+          </div>
+          <h3 className="font-serif text-xl font-black uppercase mt-1 text-[var(--foreground)]">
+            我的分享
+          </h3>
+        </div>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/feed/submit"
+            className="font-mono text-[10px] uppercase tracking-widest text-[#CC0000] hover:underline"
+          >
+            + 丢个链接
+          </Link>
+          <Link
+            href={`/u/${identifier}/shares`}
+            className="font-mono text-[10px] uppercase tracking-widest text-neutral-500 hover:text-[var(--foreground)]"
+          >
+            查看全部 →
+          </Link>
+        </div>
+      </div>
+
+      {/* 加载中：骨架 */}
+      {links === null && (
+        <div className="space-y-2">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-14 bg-neutral-100 dark:bg-neutral-900 animate-pulse"
+            />
+          ))}
+        </div>
+      )}
+
+      {/* 空态：给一个明显的 CTA 而不是冷冰冰的占位 */}
+      {links !== null && links.length === 0 && (
+        <div className="border border-dashed border-[var(--foreground)]/40 p-8 text-center">
+          <p className="text-sm text-neutral-500">
+            还没分享过任何文章。看到好东西随手丢个链接，AI 会自动归类。
+          </p>
+          <Link
+            href="/feed/submit"
+            className="mt-4 inline-block font-mono text-xs uppercase tracking-widest text-[#CC0000] hover:underline"
+          >
+            去分享第一篇 →
+          </Link>
+        </div>
+      )}
+
+      {/* 列表：最多展示 6 条，超过跳 /shares 全览 */}
+      {links !== null && links.length > 0 && (
+        <ol className="flex flex-col">
+          {links.slice(0, 6).map((link, idx) => (
+            <li
+              key={link.id}
+              className="flex items-center gap-3 py-3 border-b border-[var(--foreground)]/10 last:border-b-0"
+            >
+              <span className="font-mono text-xs text-neutral-400 w-6 flex-shrink-0">
+                {String(idx + 1).padStart(2, "0")}
+              </span>
+              <span
+                className={`rounded-full px-2 py-0.5 text-[10px] font-medium flex-shrink-0 ${STATUS_BADGE[link.status].className}`}
+              >
+                {STATUS_BADGE[link.status].label}
+              </span>
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-1 min-w-0 truncate text-sm font-medium hover:underline"
+                title={link.ogTitle ?? link.url}
+              >
+                {link.ogTitle ?? link.url}
+              </a>
+              <span className="text-[10px] font-mono text-neutral-400 flex-shrink-0 hidden sm:inline">
+                {link.host}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/app/u/[username]/page.tsx
+++ b/app/u/[username]/page.tsx
@@ -9,6 +9,8 @@ import { ProfileCard } from "./ProfileCard";
 import { EditLinkIfOwner } from "./EditLinkIfOwner";
 import { AdminLinkIfOwnerAdmin } from "./AdminLinkIfOwnerAdmin";
 import { DeveloperToolsIfOwner } from "./DeveloperToolsIfOwner";
+import { SharesLinkIfOwner } from "./SharesLinkIfOwner";
+import { SharesOnProfile } from "./SharesOnProfile";
 import { ActivityHeatmap } from "./ActivityHeatmap";
 import { FollowButton } from "./FollowButton";
 import { GithubRepos, GithubReposSkeleton } from "./GithubRepos";
@@ -388,6 +390,12 @@ export default async function UserProfilePage({ params }: Param) {
                   ownerUsername={user.username}
                   identifier={username}
                 />
+                {/* 我的分享入口：本人访问自己主页时显示，跳 /u/{identifier}/shares */}
+                <SharesLinkIfOwner
+                  ownerGithubId={user.githubId ?? null}
+                  ownerUsername={user.username}
+                  identifier={username}
+                />
                 {/* 开发者工具入口（所有本人都看得见；权限由目标服务自己管）：
                     目前只有 Infisical 密钥管理，未来可挂 CI token / API key 等 */}
                 <DeveloperToolsIfOwner
@@ -485,40 +493,46 @@ export default async function UserProfilePage({ params }: Param) {
               )}
             </section>
 
-            {/* 右侧小卡区 */}
-            <div className="col-span-12 lg:col-span-7 grid grid-cols-1 sm:grid-cols-2 gap-8">
-              {projects.map((p, idx) => (
-                <ProfileCard
-                  key={`proj-${idx}`}
-                  kind="PROJ"
-                  index={idx + 1}
-                  title={p.title}
-                  meta={p.tags?.join(" · ")}
-                  summary={p.description}
-                  detail={p.description}
-                  href={sanitizeExternalUrl(p.url) ?? undefined}
+            {/* 右侧小卡区。
+                - projects/papers 有内容时：走内部 bento grid 展示卡片
+                - 二者都空时：直接把"我的分享"作为 col-span-7 的直接子元素，
+                  让它通过父 grid 默认 align-items:stretch 自动撑到与左侧 identity 卡同高。
+                  之所以不混在内部 grid 里：嵌套 grid 的 row 高度由内容决定，
+                  `h-full` 传不下去，会出现高度循环问题。 */}
+            <div className="col-span-12 lg:col-span-7">
+              {projects.length === 0 && papers.length === 0 ? (
+                <SharesOnProfile
+                  ownerGithubId={user.githubId ?? null}
+                  ownerUsername={user.username}
+                  identifier={username}
                 />
-              ))}
-              {papers.map((p, idx) => (
-                <ProfileCard
-                  key={`paper-${idx}`}
-                  kind="PAPER"
-                  index={idx + 1}
-                  // title 在 UserPaperItem 里允许 itemKey-only（title 可能缺），这里兜底
-                  title={p.title || p.itemKey || "(untitled paper)"}
-                  meta={[p.authors, p.year].filter(Boolean).join(", ")}
-                  summary={p.abstract}
-                  detail={p.abstract}
-                  href={sanitizeExternalUrl(p.url) ?? undefined}
-                />
-              ))}
-              {projects.length === 0 && papers.length === 0 && (
-                <div className="col-span-full border border-dashed border-[var(--foreground)] p-10 text-center text-neutral-500 font-sans text-sm leading-relaxed">
-                  {t("empty.title")}
-                  <br />
-                  <span className="text-xs text-neutral-400">
-                    {t("empty.subtitle")}
-                  </span>
+              ) : (
+                <div className="h-full grid grid-cols-1 sm:grid-cols-2 gap-8">
+                  {projects.map((p, idx) => (
+                    <ProfileCard
+                      key={`proj-${idx}`}
+                      kind="PROJ"
+                      index={idx + 1}
+                      title={p.title}
+                      meta={p.tags?.join(" · ")}
+                      summary={p.description}
+                      detail={p.description}
+                      href={sanitizeExternalUrl(p.url) ?? undefined}
+                    />
+                  ))}
+                  {papers.map((p, idx) => (
+                    <ProfileCard
+                      key={`paper-${idx}`}
+                      kind="PAPER"
+                      index={idx + 1}
+                      // title 在 UserPaperItem 里允许 itemKey-only（title 可能缺），这里兜底
+                      title={p.title || p.itemKey || "(untitled paper)"}
+                      meta={[p.authors, p.year].filter(Boolean).join(", ")}
+                      summary={p.abstract}
+                      detail={p.abstract}
+                      href={sanitizeExternalUrl(p.url) ?? undefined}
+                    />
+                  ))}
                 </div>
               )}
             </div>

--- a/app/u/[username]/shares/layout.tsx
+++ b/app/u/[username]/shares/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import { Header } from "@/app/components/Header";
+import { Footer } from "@/app/components/Footer";
+
+/**
+ * /u/[username]/shares 的 Server Component layout。
+ *
+ * shares/page.tsx 是 client 组件（依赖 useAuth 判定本人身份），
+ * 不能直接渲染 async Server Component Header / Footer；提到这一层 Server Layout。
+ */
+export default function SharesLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Header />
+      {children}
+      <Footer />
+    </>
+  );
+}

--- a/app/u/[username]/shares/page.tsx
+++ b/app/u/[username]/shares/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { use, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { useAuth } from "@/lib/use-auth";
+import { Header } from "@/app/components/Header";
+import { Footer } from "@/app/components/Footer";
+import { LinkCard } from "@/app/feed/components/LinkCard";
+import type { ApiResponse, SharedLinkView } from "@/app/feed/types";
+
+/**
+ * 用户自己的分享列表页（"我提交的"）。
+ *
+ * 可见性规则（v1 最简）：
+ *   - 本人登录：渲染自己所有状态的分享（PENDING / APPROVED / FLAGGED / ARCHIVED…）
+ *   - 其他人访问：v1 暂时不展示列表，提示"仅本人可见"
+ *
+ * 为什么纯 client：列表需要 satoken 才能拉，SSR 没法带 header，就不费劲走 server fetch 了。
+ * 将来如果要做公开展示别人的 APPROVED 分享，需要后端新增
+ * GET /api/community/users/{username}/shares 再改这里（M8+ 的事）。
+ */
+
+// 页面的 status 展示 badge 颜色映射
+const STATUS_BADGE: Record<
+  SharedLinkView["status"],
+  { label: string; className: string }
+> = {
+  PENDING: { label: "审核中", className: "bg-amber-100 text-amber-900" },
+  APPROVED: { label: "已通过", className: "bg-emerald-100 text-emerald-900" },
+  PENDING_MANUAL: {
+    label: "人工待审",
+    className: "bg-orange-100 text-orange-900",
+  },
+  FLAGGED: { label: "需要复核", className: "bg-red-100 text-red-900" },
+  REJECTED: { label: "已拒绝", className: "bg-zinc-200 text-zinc-700" },
+  ARCHIVED: { label: "原文已失效", className: "bg-zinc-100 text-zinc-600" },
+};
+
+interface PageProps {
+  params: Promise<{ username: string }>;
+}
+
+export default function SharesPage({ params }: PageProps) {
+  const { username } = use(params);
+  const { user, status } = useAuth();
+  const tFeed = useTranslations("feed");
+  const tCategory = useTranslations("feed.category");
+  const [links, setLinks] = useState<SharedLinkView[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // 是否为本人访问自己的页面
+  const isOwner = useMemo(() => {
+    if (status !== "authenticated" || !user) return false;
+    return user.username === username;
+  }, [status, user, username]);
+
+  useEffect(() => {
+    // 只给本人拉数据，其他访客根本不请求后端
+    if (!isOwner) return;
+    let aborted = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/community/links/mine", {
+          cache: "no-store",
+        });
+        if (!res.ok) {
+          if (!aborted) setLoadError(`HTTP ${res.status}`);
+          return;
+        }
+        const body = (await res.json()) as ApiResponse<SharedLinkView[]>;
+        if (!aborted) {
+          if (body.success && body.data) setLinks(body.data);
+          else setLoadError(body.message ?? "加载失败");
+        }
+      } catch (err) {
+        if (!aborted) setLoadError(String(err));
+      }
+    })();
+    return () => {
+      aborted = true;
+    };
+  }, [isOwner]);
+
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-5xl px-6 py-12">
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight">我提交的分享</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {isOwner
+              ? "所有已提交的链接及审核状态。PENDING 表示 AI 正在审核，通常 10 秒 ~ 数分钟。"
+              : "仅本人可见。"}
+          </p>
+        </header>
+
+        {/* 非本人访问：给一个回到公共 /feed 的入口，避免页面显得空 */}
+        {!isOwner && (
+          <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+            <p>这是 {username} 的私有分享列表，只有本人登录后可见。</p>
+            <Link
+              href="/feed"
+              className="mt-4 inline-block text-primary underline underline-offset-4"
+            >
+              浏览公共分享墙 →
+            </Link>
+          </div>
+        )}
+
+        {isOwner && loadError && (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+            加载失败：{loadError}
+          </div>
+        )}
+
+        {isOwner && !loadError && links === null && (
+          <p className="text-sm text-muted-foreground">加载中...</p>
+        )}
+
+        {isOwner && links !== null && links.length === 0 && (
+          <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+            <p>{tFeed("empty")}</p>
+            <Link
+              href="/feed/submit"
+              className="mt-4 inline-block text-primary underline underline-offset-4"
+            >
+              去提交第一条 →
+            </Link>
+          </div>
+        )}
+
+        {isOwner && links !== null && links.length > 0 && (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {links.map((link) => (
+              <div key={link.id} className="relative">
+                {/* 状态 badge 叠在卡片左上角，本人才看得到（只有这页拉） */}
+                <span
+                  className={`absolute left-3 top-3 z-10 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_BADGE[link.status].className}`}
+                >
+                  {STATUS_BADGE[link.status].label}
+                </span>
+                <LinkCard
+                  link={link}
+                  categoryLabel={link.category ? tCategory(link.category) : ""}
+                  isLoggedIn={true}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/u/[username]/shares/page.tsx
+++ b/app/u/[username]/shares/page.tsx
@@ -4,8 +4,6 @@ import { use, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useAuth } from "@/lib/use-auth";
-import { Header } from "@/app/components/Header";
-import { Footer } from "@/app/components/Footer";
 import { LinkCard } from "@/app/feed/components/LinkCard";
 import type { ApiResponse, SharedLinkView } from "@/app/feed/types";
 
@@ -49,10 +47,16 @@ export default function SharesPage({ params }: PageProps) {
   const [links, setLinks] = useState<SharedLinkView[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  // 是否为本人访问自己的页面
+  // 是否为本人访问自己的页面。
+  // URL 的 [username] 参数可能是 "github_114939201" 也可能是 "114939201"（纯 githubId）
+  // —— 个人主页 canonical URL 已用 githubId，所以两种格式都要支持。
+  // 判定逻辑照搬 EditLinkIfOwner：githubId 优先，username 兜底。
   const isOwner = useMemo(() => {
     if (status !== "authenticated" || !user) return false;
-    return user.username === username;
+    if (user.githubId != null && String(user.githubId) === username)
+      return true;
+    if (user.username === username) return true;
+    return false;
   }, [status, user, username]);
 
   useEffect(() => {
@@ -83,74 +87,70 @@ export default function SharesPage({ params }: PageProps) {
   }, [isOwner]);
 
   return (
-    <>
-      <Header />
-      <main className="mx-auto max-w-5xl px-6 py-12">
-        <header className="mb-8">
-          <h1 className="text-3xl font-bold tracking-tight">我提交的分享</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            {isOwner
-              ? "所有已提交的链接及审核状态。PENDING 表示 AI 正在审核，通常 10 秒 ~ 数分钟。"
-              : "仅本人可见。"}
-          </p>
-        </header>
+    <main className="mx-auto max-w-5xl px-6 py-12">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight">我提交的分享</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {isOwner
+            ? "所有已提交的链接及审核状态。PENDING 表示 AI 正在审核，通常 10 秒 ~ 数分钟。"
+            : "仅本人可见。"}
+        </p>
+      </header>
 
-        {/* 非本人访问：给一个回到公共 /feed 的入口，避免页面显得空 */}
-        {!isOwner && (
-          <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
-            <p>这是 {username} 的私有分享列表，只有本人登录后可见。</p>
-            <Link
-              href="/feed"
-              className="mt-4 inline-block text-primary underline underline-offset-4"
-            >
-              浏览公共分享墙 →
-            </Link>
-          </div>
-        )}
+      {/* 非本人访问：给一个回到公共 /feed 的入口，避免页面显得空 */}
+      {!isOwner && (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          <p>这是 {username} 的私有分享列表，只有本人登录后可见。</p>
+          <Link
+            href="/feed"
+            className="mt-4 inline-block text-primary underline underline-offset-4"
+          >
+            浏览公共分享墙 →
+          </Link>
+        </div>
+      )}
 
-        {isOwner && loadError && (
-          <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
-            加载失败：{loadError}
-          </div>
-        )}
+      {isOwner && loadError && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          加载失败：{loadError}
+        </div>
+      )}
 
-        {isOwner && !loadError && links === null && (
-          <p className="text-sm text-muted-foreground">加载中...</p>
-        )}
+      {isOwner && !loadError && links === null && (
+        <p className="text-sm text-muted-foreground">加载中...</p>
+      )}
 
-        {isOwner && links !== null && links.length === 0 && (
-          <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
-            <p>{tFeed("empty")}</p>
-            <Link
-              href="/feed/submit"
-              className="mt-4 inline-block text-primary underline underline-offset-4"
-            >
-              去提交第一条 →
-            </Link>
-          </div>
-        )}
+      {isOwner && links !== null && links.length === 0 && (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          <p>{tFeed("empty")}</p>
+          <Link
+            href="/feed/submit"
+            className="mt-4 inline-block text-primary underline underline-offset-4"
+          >
+            去提交第一条 →
+          </Link>
+        </div>
+      )}
 
-        {isOwner && links !== null && links.length > 0 && (
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {links.map((link) => (
-              <div key={link.id} className="relative">
-                {/* 状态 badge 叠在卡片左上角，本人才看得到（只有这页拉） */}
-                <span
-                  className={`absolute left-3 top-3 z-10 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_BADGE[link.status].className}`}
-                >
-                  {STATUS_BADGE[link.status].label}
-                </span>
-                <LinkCard
-                  link={link}
-                  categoryLabel={link.category ? tCategory(link.category) : ""}
-                  isLoggedIn={true}
-                />
-              </div>
-            ))}
-          </div>
-        )}
-      </main>
-      <Footer />
-    </>
+      {isOwner && links !== null && links.length > 0 && (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {links.map((link) => (
+            <div key={link.id} className="relative">
+              {/* 状态 badge 叠在卡片左上角，本人才看得到（只有这页拉） */}
+              <span
+                className={`absolute left-3 top-3 z-10 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_BADGE[link.status].className}`}
+              >
+                {STATUS_BADGE[link.status].label}
+              </span>
+              <LinkCard
+                link={link}
+                categoryLabel={link.category ? tCategory(link.category) : ""}
+                isLoggedIn={true}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
   );
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,7 +9,6 @@
   },
   "hero": {
     "mission": "A free, open learning community built by developers, for developers. No gatekeeping, no pointless grind — just real progress and the joy of building. Knowledge is a ladder to freedom, not a cage.",
-    "feedLink": "📎 Got a good read? Drop a link →",
     "cta": {
       "access": "Access Articles",
       "guideAriaLabel": "Contribution Guide"
@@ -443,5 +442,9 @@
       "placeholder": "my-article",
       "hint": "Auto-appends .md"
     }
+  },
+  "shareLink": {
+    "button": "Share Link",
+    "submitAriaLabel": "Quick submit"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,6 +9,7 @@
   },
   "hero": {
     "mission": "A free, open learning community built by developers, for developers. No gatekeeping, no pointless grind — just real progress and the joy of building. Knowledge is a ladder to freedom, not a cage.",
+    "feedLink": "📎 Got a good read? Drop a link →",
     "cta": {
       "access": "Access Articles",
       "guideAriaLabel": "Contribution Guide"
@@ -157,6 +158,49 @@
       "submit": "Continue on GitHub"
     },
     "guideAriaLabel": "Contribution Guide"
+  },
+  "feed": {
+    "title": "Community Feed",
+    "subtitle": "Good reads curated by the community — paste a link, share the knowledge.",
+    "empty": "No approved shares yet. Be the first to submit one!",
+    "submit": {
+      "title": "Drop a Link",
+      "urlLabel": "Article URL (required)",
+      "urlPlaceholder": "https://mp.weixin.qq.com/...",
+      "recommendationLabel": "Why recommend it? (optional, max 200 chars)",
+      "recommendationPlaceholder": "What makes this worth reading?",
+      "submitButton": "Submit",
+      "submitting": "Submitting...",
+      "successToast": "Submitted! AI is reviewing your link...",
+      "loginRequired": "Sign in to submit a link",
+      "charCount": "{count}/200"
+    },
+    "card": {
+      "reportButton": "Report",
+      "ogFallback": "Cover / excerpt unavailable",
+      "archivedBadge": "Link expired",
+      "visitLink": "Visit",
+      "submittedBy": "by"
+    },
+    "report": {
+      "title": "Report this link",
+      "reasonLabel": "Reason (optional)",
+      "reasonPlaceholder": "Describe the issue...",
+      "submitButton": "Submit Report",
+      "successToast": "Report submitted, thanks!",
+      "loginRequired": "Sign in to report"
+    },
+    "category": {
+      "all": "All",
+      "ai_frontier": "AI Frontier",
+      "engineering": "Engineering",
+      "job": "Jobs & Internships",
+      "grad_study": "Grad & Study Abroad",
+      "industry": "Industry",
+      "learning": "Learning",
+      "lifestyle": "Lifestyle",
+      "other": "Other"
+    }
   },
   "search": {
     "placeholder": "Search docs...",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -9,7 +9,6 @@
   },
   "hero": {
     "mission": "一个由开发者自发组织、免费开放的学习社区。降低门槛，避免无意义内卷，专注真实进步与乐趣。我们相信知识不应成为枷锁，而应是通往自由的阶梯。",
-    "feedLink": "📎 看到好文章？丢个链接 →",
     "cta": {
       "access": "访问文章",
       "guideAriaLabel": "查看投稿指南"
@@ -443,5 +442,9 @@
       "placeholder": "my-article",
       "hint": "自动添加 .md 后缀"
     }
+  },
+  "shareLink": {
+    "button": "丢个链接",
+    "submitAriaLabel": "快速提交"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -9,6 +9,7 @@
   },
   "hero": {
     "mission": "一个由开发者自发组织、免费开放的学习社区。降低门槛，避免无意义内卷，专注真实进步与乐趣。我们相信知识不应成为枷锁，而应是通往自由的阶梯。",
+    "feedLink": "📎 看到好文章？丢个链接 →",
     "cta": {
       "access": "访问文章",
       "guideAriaLabel": "查看投稿指南"
@@ -157,6 +158,49 @@
       "submit": "继续在 GitHub 新建页面"
     },
     "guideAriaLabel": "查看投稿指南"
+  },
+  "feed": {
+    "title": "社区分享墙",
+    "subtitle": "群友精选好文，随手转发，沉淀有价值的信息流。",
+    "empty": "暂无已审核通过的分享，快来第一个投稿吧！",
+    "submit": {
+      "title": "丢个链接",
+      "urlLabel": "文章链接（必填）",
+      "urlPlaceholder": "https://mp.weixin.qq.com/...",
+      "recommendationLabel": "一句话推荐（选填，最多 200 字）",
+      "recommendationPlaceholder": "为什么推荐这篇？",
+      "submitButton": "提交",
+      "submitting": "提交中...",
+      "successToast": "提交成功，AI 正在审核...",
+      "loginRequired": "请先登录再提交",
+      "charCount": "{count}/200"
+    },
+    "card": {
+      "reportButton": "举报",
+      "ogFallback": "封面/摘要未能抓取",
+      "archivedBadge": "原文已失效",
+      "visitLink": "查看原文",
+      "submittedBy": "by"
+    },
+    "report": {
+      "title": "举报这条分享",
+      "reasonLabel": "举报原因（选填）",
+      "reasonPlaceholder": "请描述问题...",
+      "submitButton": "提交举报",
+      "successToast": "举报已提交，感谢反馈",
+      "loginRequired": "请登录后举报"
+    },
+    "category": {
+      "all": "全部",
+      "ai_frontier": "AI 前沿",
+      "engineering": "工程实践",
+      "job": "求职 & 实习",
+      "grad_study": "考研 & 留学",
+      "industry": "行业观察",
+      "learning": "学习方法",
+      "lifestyle": "生活 & 随笔",
+      "other": "其他"
+    }
   },
   "search": {
     "placeholder": "搜索文档...",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -284,6 +284,16 @@ const config = {
         source: "/api/admin/users/:path*",
         destination: `${backendUrl}/api/admin/users/:path*`,
       },
+      {
+        // 社区分享链接公开读 + 提交 + 举报（/api/community/links 及子路径）
+        // 与 Events 模块风格一致：根路径 + 子路径各一条
+        source: "/api/community/links",
+        destination: `${backendUrl}/api/community/links`,
+      },
+      {
+        source: "/api/community/links/:path*",
+        destination: `${backendUrl}/api/community/links/:path*`,
+      },
     ];
   },
   images: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -294,6 +294,15 @@ const config = {
         source: "/api/community/links/:path*",
         destination: `${backendUrl}/api/community/links/:path*`,
       },
+      {
+        // 社区分享 admin 路由：列表、通过、拒绝（走 @SaCheckRole("admin")）
+        source: "/api/admin/community",
+        destination: `${backendUrl}/api/admin/community`,
+      },
+      {
+        source: "/api/admin/community/:path*",
+        destination: `${backendUrl}/api/admin/community/:path*`,
+      },
     ];
   },
   images: {


### PR DESCRIPTION
## 背景

配套 backend PR [InvolutionHell/involutionhell-backend#16](https://github.com/InvolutionHell/involutionhell-backend/pull/16)。社区分享链接墙前端侧实现。完整设计锁定见 [wiki/Community-Shared-Links](https://github.com/InvolutionHell/involutionhell.github.io/wiki/Community-Shared-Links)。

## 新增页面

### 用户侧
- **Hero 入口**：\`Contribute\` 按钮下方新增次级文字链 \`📎 看到好文章？丢个链接 →\` 跳 \`/feed\`，斜体 muted 样式，不抢主 CTA 焦点
- **\`/feed\`**（SSR + revalidate 120s）：瀑布流 + 分类 tab，空状态/加载态完整
- **\`/feed/submit\`**：提交表单，URL + 推荐语（200 字上限），未登录跳 \`/login?next=/feed/submit\`
- **\`/u/[username]/shares\`**：本人可见自己所有状态的分享（含 PENDING / FLAGGED / ARCHIVED badge）

### 组件
- \`LinkCard\` 整卡可点跳原文（\`target="_blank" rel="noopener noreferrer"\`），OG 封面缺失时回退到 host 首字母占位
- \`CategoryTabs\` URL searchParam 驱动，移动端横向滚动
- \`ReportButton\` 举报 dialog，未登录态给 alert 提示
- \`FeedAuthWrapper\` SSR/client 登录态桥接

### 管理员侧
- **\`/admin/community\`**：待审列表（PENDING_MANUAL + FLAGGED）+ 通过/拒绝按钮，复用 \`AdminGuard\`

### i18n
- \`messages/{zh,en}.json\` 新增 \`feed.*\` + \`hero.feedLink\` 命名空间
- 分类展示名走 i18n（枚举 slug 仍为固定英文）

### rewrite
- \`next.config.mjs\` 加 \`/api/community/links\` 和 \`/api/admin/community\` 两对 rewrite 到 backend:8081

## Test Plan

- [ ] 启 frontend:3010 + backend:8081 看 Hero 文字链是否协调
- [ ] 登录后提交一条 https://mp.weixin.qq.com/s/... → 看 submit 跳转 + 异步 worker 完成后 /feed 显示
- [ ] 举报按钮：未登录 alert，登录后 dialog 提交
- [ ] 分类 tab 切换 URL searchParam 生效
- [ ] /u/[username]/shares 非本人访问看到"仅本人可见"
- [ ] admin 面板 approve/reject 按钮工作，列表实时刷新

## 视觉 review 关注点

1. Hero 文字链位置与 Contribute 按钮的间距是否合适（当前 \`mt-4\`）
2. LinkCard 封面比例 \`aspect-[16/9]\` —— 公众号/知乎 OG 图可能是 1:1/3:4，\`object-cover\` 会裁
3. 分类 tab 移动端 9 个横滚手感