### PR TITLE
fix(community): OG 封面 referrerPolicy=no-referrer 规避微信防盗链裂图

### DIFF
--- a/app/admin/community/page.tsx
+++ b/app/admin/community/page.tsx
@@ -12,7 +12,6 @@
  */
 
 import { useEffect, useState } from "react";
-import Image from "next/image";
 import { AdminGuard } from "@/app/admin/events/AdminGuard";
 import type { SharedLinkView } from "@/app/feed/types";
 import { sanitizeExternalUrl } from "@/lib/url-safety";
@@ -130,16 +129,18 @@ function AdminCommunityInner() {
                 key={link.id}
                 className="border border-[var(--foreground)]/40 p-4 flex flex-col md:flex-row gap-4"
               >
-                {/* 左：OG 封面缩略图（没抓到就占位） */}
+                {/* 左：OG 封面缩略图（没抓到就占位）。
+                    改用 <img> + referrerPolicy="no-referrer"：微信/知乎/小红书
+                    图床防盗链会检查 Referer，非本站来源返回"未经允许"裂图。
+                    next/image 的 remotePatterns 限制外站域名也一并规避。 */}
                 <div className="w-full md:w-40 aspect-[16/9] flex-shrink-0 bg-neutral-100 dark:bg-neutral-900 relative overflow-hidden">
                   {link.ogCover ? (
-                    <Image
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
                       src={link.ogCover}
                       alt={link.ogTitle ?? link.url}
-                      fill
-                      sizes="160px"
-                      className="object-cover"
-                      unoptimized
+                      referrerPolicy="no-referrer"
+                      className="absolute inset-0 w-full h-full object-cover"
                     />
                   ) : (
                     <span className="absolute inset-0 flex items-center justify-center text-3xl font-bold text-neutral-400">

--- a/app/feed/components/LinkCard.tsx
+++ b/app/feed/components/LinkCard.tsx
@@ -40,11 +40,15 @@ export function LinkCard({ link, categoryLabel, isLoggedIn }: LinkCardProps) {
       >
         {/* OG 封面 / 占位块 */}
         {link.ogCover && !link.ogFetchFailed ? (
-          // next/image 全站 unoptimized:true，用 img 即可（与 events 页一致）
+          // next/image 全站 unoptimized:true，用 img 即可（与 events 页一致）。
+          // referrerPolicy="no-referrer"：微信 mmbiz.qpic.cn 防盗链会检查 Referer，
+          // 非 mp.weixin.qq.com 来源直接返回"未经允许使用"裂图；不发 Referer 时
+          // 反而放行（微信客户端内打开文章浏览器也不发 Referer）。
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={link.ogCover}
             alt={link.ogTitle ?? link.host}
+            referrerPolicy="no-referrer"
             className="w-full aspect-[16/9] object-cover border-b border-[var(--foreground)]"
           />
         ) : (


### PR DESCRIPTION
## 症状

/feed 列表里微信公众号卡片封面显示裂图："此图片来自微信公众平台未经允许不可使用"。

## 原因

微信 \`mmbiz.qpic.cn\` 对图片请求检查 Referer：
- Referer 不是 \`mp.weixin.qq.com\` → 返回裂图
- **不发 Referer → 放行**（微信客户端打开文章时浏览器也不发 Referer，所以这是微信自己的兼容路径）

知乎 \`pic*.zhimg.com\` / 小红书 \`ci.xiaohongshu.com\` 同样策略。

## 改动

- \`LinkCard\`: \`<img>\` 加 \`referrerPolicy=\"no-referrer\"\`
- \`/admin/community\`: 原来的 \`next/image\` 换成 \`<img>\` + \`referrerPolicy\`（顺手规避 next/image \`remotePatterns\` 对外站图床的白名单限制——Copilot CR 之前提过，当时靠 \`unoptimized\` 绕，现在统一切 \`<img>\` 更干净）

## 验证

- typecheck 0 errors
- vitest 1/1 绿
- 本地 dev 可在 \`/feed\` 看真实公众号卡片封面正常加载（有可测试数据的话）