### PR TITLE
fix(not-found): 改 Server Component 修 Server Action 路径下 useTranslations 崩溃

### DIFF
--- a/app/not-found-tracker.tsx
+++ b/app/not-found-tracker.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+// 从 not-found.tsx 拆出来的 umami 404 埋点。
+// 拆分原因：not-found.tsx 必须保持 Server Component（见同目录 not-found.tsx 注释），
+// useEffect / usePathname / window.umami 只能在 client。
+export default function NotFoundTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (window.umami) {
+      window.umami.track("error_404", {
+        path: pathname,
+        referrer: document.referrer || "direct",
+      });
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,23 +1,14 @@
-"use client";
-
 import Link from "next/link";
-import { useEffect } from "react";
-import { usePathname } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import { Button } from "@/app/components/ui/button";
+import NotFoundTracker from "./not-found-tracker";
 
-export default function NotFound() {
-  const pathname = usePathname();
-  const t = useTranslations("notFound");
-
-  useEffect(() => {
-    if (window.umami) {
-      window.umami.track("error_404", {
-        path: pathname,
-        referrer: document.referrer || "direct",
-      });
-    }
-  }, [pathname]);
+// 必须是 Server Component：爬虫向 / 发 POST 时 Next 走 Server Action 路径，
+// not-found 渲染不经过 layout，NextIntlClientProvider 不在树里，
+// useTranslations 会抛 "No intl context"。getTranslations 走 server，
+// 直接读 i18n/request.ts，没有 provider 依赖。
+export default async function NotFound() {
+  const t = await getTranslations("notFound");
 
   return (
     <div className="flex h-screen w-full flex-col items-center justify-center bg-background text-foreground">
@@ -32,6 +23,7 @@ export default function NotFound() {
           <Link href="/">{t("cta")}</Link>
         </Button>
       </div>
+      <NotFoundTracker />
     </div>
   );
 }


### PR DESCRIPTION
## 问题
Sentry [SENTRY-BOLE-NOTEBOOK-2] —— prod 环境 \`POST /\` 请求触发 not-found 渲染时 \`useTranslations\` 抛 "No intl context"，500 上报 Sentry。

## 根因
- 爬虫向 \`/\` POST 触发 Next.js 的 Server Action 路径（Sentry tag \`route_type: action\` 已确认）
- Server Action 路径未匹配到 action 后渲染 \`not-found.tsx\`，**但不经过 root layout**
- \`<NextIntlClientProvider>\` 不在 React 树里，client hook \`useTranslations\` 直接抛错

## 修复
- \`app/not-found.tsx\` 改为 Server Component，使用 \`getTranslations\`（来自 \`next-intl/server\`）。服务端 API 直接读 \`i18n/request.ts\`，不依赖 client provider
- 把 \`useEffect\` + \`usePathname\` + umami 埋点拆出 \`app/not-found-tracker.tsx\` 作为 client 子组件挂载

## 影响
- 真实用户：0（事件均来自机器人 POST 探测）
- Sentry 噪声会清零，避免后续真错被淹没

## Test plan
- [x] tsc --noEmit 通过
- [x] vitest 通过（lint-staged 跑过）
- [ ] preview 部署后访问 \`/\` 走 GET → 正常 404 页（中英文双语正确显示）
- [ ] preview 部署后 \`curl -X POST https://<preview>/\` → 不再 500 上报 Sentry