### PR TITLE
feat(header): 全站导航加 "分享墙 / Feed" 入口

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -60,6 +60,15 @@ export async function Header() {
               {t("nav.community")}
             </Link>
             <Link
+              href="/feed"
+              className="hover:text-[#CC0000] transition-colors"
+              data-umami-event="navigation_click"
+              data-umami-event-region="header"
+              data-umami-event-label="feed"
+            >
+              {t("nav.feed")}
+            </Link>
+            <Link
               href="/#contact"
               className="hover:text-[#CC0000] transition-colors"
               data-umami-event="navigation_click"

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,6 +4,7 @@
       "docs": "Docs",
       "rank": "Rank",
       "community": "Community",
+      "feed": "Feed",
       "contact": "Contact"
     }
   },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -4,6 +4,7 @@
       "docs": "文档",
       "rank": "排行榜",
       "community": "社区",
+      "feed": "分享墙",
       "contact": "联系"
     }
   },


### PR DESCRIPTION
## 背景
之前 Hero / Join 区有 \`/feed\` 入口但全站 header 没有，用户在文档页 / 排行榜等子页面想跳分享墙必须先回首页或敲 URL。

## 改动
\`app/components/Header.tsx\`: nav 加一条 \`Link href="/feed"\`，紧跟"社区"。
顺序: **文档 / 排行榜 / 社区 / 分享墙 / 联系**

## 文案
| locale | 文案 | 理由 |
|---|---|---|
| zh | **分享墙** | "墙"对齐"排行榜"的"榜"，强调信息流形态而非命令句 |
| en | **Feed** | 简短统一 |

## 埋点
\`data-umami-event-label="feed"\` 跟其他 nav 项一致，方便后续看转化率。

## Test plan
- [x] tsc --noEmit 通过
- [x] lint 通过（pre-existing warnings）
- [x] vitest 通过
- [x] preview 看桌面 nav 是否真的多出第 4 项 + 中英文切换正确