### PR TITLE
fix(leaderboard): UA 改回 InvolutionHell-SSR + fallback 保留旧 JSON (re-PR #325)

### DIFF
--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -103,15 +103,15 @@ async function fetchAggregatedFromBackend() {
     const res = await fetch(LEADERBOARD_API_URL, {
       headers: {
         accept: "application/json",
-        // UA 用 Chrome 伪装：API 站点走 Cloudflare，CF 默认 Bot Fight Mode 会
-        // 把任何含 "bot" / "build" / "script" 关键词的 UA 当机器人拦下，回
-        // 403 + "Just a moment..." 挑战页（之前的 UA 就被这么拦了，导致 prod
-        // build 拿到 403 走 fallback 写空 leaderboard，feed 卡片全空）。
-        // 长期方案应是在 CF 给 /api/public/* 加 "Skip Bot Fight" 规则白名单，
-        // 这里的 UA 伪装只是兜底。
+        // UA 必须包含 "InvolutionHell-SSR" —— 这是 CF Custom Rule 的匹配触发词：
+        //   (http.host eq "api.involutionhell.com" and http.user_agent contains "InvolutionHell-SSR")
+        //   → Skip Bot Fight / Browser Integrity / Managed Rules
+        // 之前用 Chrome 伪装时 UA 不含这个 token，CF 规则不匹配，Vercel build runner
+        // 仍然被 IP 信誉评分判定为 bot 回 403（"Just a moment..." 挑战页）。
+        // 改回带 token 的 UA 让 CF 规则真正放行。
         "user-agent":
-          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
-          "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+          "InvolutionHell-SSR/1.0 (build; generate-leaderboard.mjs; " +
+          "+https://involutionhell.com)",
       },
       signal: controller.signal,
     });

--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -103,7 +103,15 @@ async function fetchAggregatedFromBackend() {
     const res = await fetch(LEADERBOARD_API_URL, {
       headers: {
         accept: "application/json",
-        "user-agent": "InvolutionHell-build/1.0 (generate-leaderboard.mjs)",
+        // UA 用 Chrome 伪装：API 站点走 Cloudflare，CF 默认 Bot Fight Mode 会
+        // 把任何含 "bot" / "build" / "script" 关键词的 UA 当机器人拦下，回
+        // 403 + "Just a moment..." 挑战页（之前的 UA 就被这么拦了，导致 prod
+        // build 拿到 403 走 fallback 写空 leaderboard，feed 卡片全空）。
+        // 长期方案应是在 CF 给 /api/public/* 加 "Skip Bot Fight" 规则白名单，
+        // 这里的 UA 伪装只是兜底。
+        "user-agent":
+          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
+          "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
       },
       signal: controller.signal,
     });

--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -153,12 +153,53 @@ async function main() {
   const aggregated = await fetchAggregatedFromBackend();
 
   if (aggregated === null) {
+    // 拉不到后端时优先保留 generated/site-leaderboard.json 旧版本：
+    // 一次 fetch 失败（CF 临时挑战 / Vercel runner IP 信誉低 / 后端短暂抖动）
+    // 不应该把 commit 进 git 的好数据冲成空数组上线。
+    //
+    // 三种情况：
+    //   1. 文件已存在 + 内容是非空数组 → 保留旧数据 exit 0
+    //   2. 文件已存在但是空数组 / 不是数组 → 维持原状 exit 0（不主动覆盖）
+    //   3. 文件不存在（首次 build / 干净 cache）→ 写空数组兜底 exit 0
+    let preservedExisting = false;
+    try {
+      const existing = await fs.readFile(outputAbs, "utf-8");
+      try {
+        const parsed = JSON.parse(existing);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          console.warn(
+            `[generate-leaderboard] 后端不可用，但保留 ${OUTPUT} 已有 ${parsed.length} 条数据，不覆盖。 | Backend unreachable; keeping existing leaderboard with ${parsed.length} entries.`,
+          );
+        } else {
+          console.warn(
+            `[generate-leaderboard] 后端不可用，且 ${OUTPUT} 已有内容非有效非空数组，维持原状。`,
+          );
+        }
+        preservedExisting = true;
+      } catch {
+        // 文件存在但 JSON 损坏：当作没有，走下面写空兜底
+        console.warn(
+          `[generate-leaderboard] ${OUTPUT} 已存在但 JSON 解析失败，按"首次 build"兜底覆盖空数组。`,
+        );
+      }
+    } catch (readErr) {
+      // ENOENT 等：文件不存在，走兜底
+      if (readErr && readErr.code !== "ENOENT") {
+        console.warn(
+          "[generate-leaderboard] 读取既有 leaderboard 失败：",
+          readErr instanceof Error ? readErr.message : readErr,
+        );
+      }
+    }
+
+    if (preservedExisting) {
+      process.exit(0);
+    }
+
+    // 文件不存在 / 损坏：写空兜底，避免后续 Next import 抛 ENOENT
     console.error(
-      "[generate-leaderboard] 后端不可用，写入空榜单以放行构建。 | Backend unreachable, writing empty leaderboard to unblock build.",
+      "[generate-leaderboard] 后端不可用且本地无可保留数据，写入空榜单以放行构建。 | Backend unreachable and no existing data, writing empty leaderboard to unblock build.",
     );
-    // mkdir + writeFile 必须放同一个 try：任一步失败都意味着 generated/site-leaderboard.json
-    // 不存在，后续 Next 端 import 会抛更难定位的 ENOENT。这种情况 build 必须 fail-fast，
-    // 不能 exit 0 让"看起来一切正常"的 deploy 把站点搞挂。
     try {
       await ensureParentDir(outputAbs);
       await fs.writeFile(outputAbs, "[]", "utf-8");


### PR DESCRIPTION
PR #325 因 force-push rebase 后被 GitHub 异常关闭无法 reopen，重开本 PR。

## 修两件事

### 1. UA 改回带 InvolutionHell-SSR token
你 CF 已配 Custom Rule：
\`\`\`
(http.host eq "api.involutionhell.com" and http.user_agent contains "InvolutionHell-SSR")
→ Skip Bot Fight / Browser Integrity / Managed Rules
\`\`\`
之前我误判把 UA 改成 Chrome 伪装，CF 规则不匹配仍然被拦回 403。改回带 token 的 UA 让 CF 真正放行。本机实测 200 + 21 条数据。

### 2. fallback 优先保留旧 JSON
\`generated/site-leaderboard.json\` 已存在且非空数组时，后端拉不到数据**保留旧版**而不是写空覆盖。即便 CF 后续偶发拦截，prod 上线的 leaderboard 也只会"维持上一版"而不是"突然空了"。

## 修复路径
合并 → CI 自动 prod redeploy → build 时 CF 放行 → 拿到 21 条 → 首页 Top Rank 恢复。