### PR TITLE
fix(hotdocs): SSR fetch 加 InvolutionHell-SSR UA 让 CF 放行

### DIFF
--- a/app/components/HotDocsPreview.tsx
+++ b/app/components/HotDocsPreview.tsx
@@ -20,7 +20,17 @@ async function fetchTopDocs(): Promise<TopDocDto[]> {
   try {
     const res = await fetch(
       `${backendUrl}/analytics/top-docs?window=7d&limit=5`,
-      { next: { revalidate: 300 } },
+      {
+        next: { revalidate: 300 },
+        // UA 必须带 "InvolutionHell-SSR" token，否则 Cloudflare Bot Fight Mode
+        // 会按 Vercel runner IP 信誉判定为 bot 拦截（CF Custom Rule 用这个
+        // token 识别"自己人"放行）。其他 SSR fetcher（fetchProfile / events /
+        // feed）都已经带，唯独本组件之前漏了导致首页 "本周最热" 一直空。
+        headers: {
+          accept: "application/json",
+          "user-agent": "InvolutionHell-SSR/1.0 (+https://involutionhell.com)",
+        },
+      },
     );
     if (!res.ok) return [];
     const json = await res.json();


### PR DESCRIPTION
## 故障
首页右上角 **Hot This Week / 本周最热** 一直 "暂无数据"。
（用户截图说"Top Rank 是空的"实际是看花眼了——左侧 Top Rank 早就有 TSK-Glofy 130 PTS / 0dysseus13 100 / duang3457 80 三张卡片，空的是右侧 Hot Docs 区块。）

## 根因
直接 \`curl https://api.involutionhell.com/analytics/top-docs?window=7d&limit=5\` 200 + 5 条数据正常。
\`HotDocsPreview.tsx\` 的 SSR fetch **没带 UA header**，Vercel runner 默认 \`node\` UA 不匹配你 CF 的 Custom Rule（\`UA contains "InvolutionHell-SSR" → Skip Bot Fight\`），按 IP 信誉被拦下回 403/empty → catch 返 \`[]\` → "暂无数据"。

代码库其他 SSR fetcher 都已经带 \`InvolutionHell-SSR/1.0\` UA：
- \`fetchProfile\` (app/u/[username]/page.tsx)
- \`fetchEvents\` (app/events/page.tsx, lib/events-fetch.ts)
- \`fetchEventDetail\` (app/events/[id]/page.tsx)
- \`fetchLinks\` (app/feed/page.tsx)

唯独 HotDocsPreview 漏了。本 PR 补齐。

## Test plan
- [x] tsc 通过
- [x] lint-staged 通过
- [ ] merge 后 prod redeploy → 首页 "Hot This Week" 显示 5 条文档