### PR TITLE
fix(leaderboard): 日志区分 null 和 object (Copilot CR PR #328)

### DIFF
--- a/scripts/generate-leaderboard.mjs
+++ b/scripts/generate-leaderboard.mjs
@@ -185,8 +185,10 @@ async function main() {
           preservedExisting = true;
         } else {
           // 非数组（对象、字面量、null 等）→ 不 preserve，走下方兜底覆盖空数组
+          // typeof null === "object" 是 JS 历史包袱，单独标识避免排查时误以为是普通对象
+          const kind = parsed === null ? "null" : typeof parsed;
           console.warn(
-            `[generate-leaderboard] ${OUTPUT} 已存在但内容不是数组（typeof=${typeof parsed}），按无效数据处理，兜底覆盖为 []。`,
+            `[generate-leaderboard] ${OUTPUT} 已存在但内容不是数组（kind=${kind}），按无效数据处理，兜底覆盖为 []。`,
           );
         }
       } catch {


### PR DESCRIPTION
## CR
PR #328 Copilot 反馈：JS 历史包袱 \`typeof null === "object"\`，fallback 兜底分支日志写 \`kind=object\` 时排查者会误以为是普通对象绕半天。

## 改动
单独识别 null：
\`\`\`js
const kind = parsed === null ? "null" : typeof parsed;
\`\`\`

## 实测
- \`null\` → \`kind=null\`
- \`{...}\` → \`kind=object\`
- \`"str"\` → \`kind=string\`